### PR TITLE
feat(security): add gitleaks secret scanning and OWASP ZAP baseline scan

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     name: Detect Secrets

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,18 @@
+name: Gitleaks Secret Scanning
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  gitleaks:
+    name: Detect Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [develop]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   zap-baseline:
     name: ZAP Baseline Scan
@@ -13,16 +17,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.12.0
+        uses: zaproxy/action-baseline@v0.15.0
         with:
           target: "https://faultray.com"
           fail_action: false
-          artifact_name: zap-report
-
-      - name: Upload ZAP Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zap-report
-          path: report_html.html
-          retention-days: 30
+          artifact_name: zap-report-${{ github.sha }}

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -1,0 +1,28 @@
+name: OWASP ZAP Baseline Scan
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop]
+
+jobs:
+  zap-baseline:
+    name: ZAP Baseline Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.12.0
+        with:
+          target: "https://faultray.com"
+          fail_action: false
+          artifact_name: zap-report
+
+      - name: Upload ZAP Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: report_html.html
+          retention-days: 30


### PR DESCRIPTION
## Summary

- `gitleaks.yml`: 全ブランチのpush/PRでシークレット漏洩を検出（`gitleaks/gitleaks-action@v2`）
- `zap-scan.yml`: `https://faultray.com` に対してOWASP ZAP baselineスキャンを実行。手動トリガーまたはdevelopブランチpush時に起動。HTMLレポートをartifactとして30日保存
- `fail_action: false` で最初は警告のみ（運用後に厳格化可能）

## Test plan

- [ ] gitleaks: このPR自体にシークレットがないことを確認（ワークフロー実行結果でPass）
- [ ] ZAP scan: Actions タブから手動トリガーし、artifact `zap-report` がダウンロードできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)