### PR TITLE
fix(test): add locale layouts to XSS test allowlist

### DIFF
--- a/tests/security/xss.test.ts
+++ b/tests/security/xss.test.ts
@@ -38,6 +38,9 @@ describe("L8: XSS Prevention", () => {
       "app/[lang]/page.tsx",
       // app/en/page.tsx: static HTML entities in hardcoded persona pain points (no user input)
       "app/en/page.tsx",
+      // locale layouts: JSON-LD structured data with XSS-safe escaping (\\u003c, \\u003e, \\u0026)
+      "app/en/layout.tsx",
+      "app/ja/layout.tsx",
     ]);
 
     const violations: string[] = [];


### PR DESCRIPTION
## Summary
- Add `app/en/layout.tsx` and `app/ja/layout.tsx` to XSS test allowlist
- Both use `dangerouslySetInnerHTML` for JSON-LD with proper escaping (`\u003c`, `\u003e`, `\u0026`)
- Safe usage, same pattern as `app/layout.tsx` which was already allowed

## Test plan
- [x] `vitest run tests/security/xss.test.ts` — 4/4 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated security testing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->