### PR TITLE
fix(app): align NEXT_PUBLIC_FAULTRAY_API_URL + remove silent whatif fallback

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -143,7 +143,11 @@ export default function ReportsPage() {
 
   const downloadHtml = async () => {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || ""}/api/report-executive?format=html&lang=${reportLang}`);
+      const apiBase =
+        process.env.NEXT_PUBLIC_FAULTRAY_API_URL ||
+        process.env.NEXT_PUBLIC_API_URL ||
+        "";
+      const res = await fetch(`${apiBase}/api/report-executive?format=html&lang=${reportLang}`);
       const html = await res.text();
       const blob = new Blob([html], { type: "text/html" });
       const url = URL.createObjectURL(blob);

--- a/src/app/whatif/page.tsx
+++ b/src/app/whatif/page.tsx
@@ -33,6 +33,7 @@ export default function WhatIfPage() {
   const [value, setValue] = useState(2);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<WhatIfResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const locale = useLocale();
   const t = appDict.whatif[locale] ?? appDict.whatif.en;
@@ -40,27 +41,21 @@ export default function WhatIfPage() {
 
   const runAnalysis = async () => {
     setLoading(true);
+    setErrorMessage(null);
     try {
       const res = await api.whatIf(component, parameter, value);
       setResult(res);
-    } catch {
-      // Generate a local estimate
-      setResult({
-        baseline: { overall_score: 85.2, availability_estimate: "99.99%", nines: 4.0 },
-        modified: {
-          overall_score: Math.min(100, Math.max(0, 85.2 + (value - selectedParam.default) * 1.5)),
-          nines: 4.0 + (value - selectedParam.default) * 0.1,
-        },
-        delta: {
-          score: Math.round((value - selectedParam.default) * 1.5 * 10) / 10,
-          direction: value > selectedParam.default ? "improvement" : value < selectedParam.default ? "degradation" : "neutral",
-        },
-        component_id: component,
-        parameter,
-        original_value: selectedParam.default,
-        new_value: value,
-        available_parameters: PARAMETERS.map((p) => p.id),
-      });
+    } catch (err) {
+      // Surface the real failure rather than silently fabricating a score.
+      // Previously we returned a hardcoded `baseline: { overall_score: 85.2 }`
+      // here, which hid a misconfigured NEXT_PUBLIC_FAULTRAY_API_URL / missing
+      // backend from users (Phase 0 validation report, Task 6, 2026-04-17).
+      setResult(null);
+      setErrorMessage(
+        err instanceof Error && err.message
+          ? err.message
+          : "Analysis backend is unreachable. Check NEXT_PUBLIC_FAULTRAY_API_URL and the API service."
+      );
     } finally {
       setLoading(false);
     }
@@ -168,6 +163,23 @@ export default function WhatIfPage() {
 
         {/* Results */}
         <div className="space-y-6">
+          {errorMessage && !result ? (
+            <Card>
+              <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/40">
+                <h3 className="text-sm font-semibold text-red-400 uppercase tracking-wider mb-2">
+                  Backend unreachable
+                </h3>
+                <p className="text-sm text-[var(--text-secondary)] whitespace-pre-wrap">
+                  {errorMessage}
+                </p>
+                <p className="text-xs text-[var(--text-muted)] mt-3">
+                  Configure <code>NEXT_PUBLIC_FAULTRAY_API_URL</code> in
+                  <code>.env.local</code> (or deploy env) and ensure the
+                  FaultRay API service is running.
+                </p>
+              </div>
+            </Card>
+          ) : null}
           {result ? (
             <>
               <Card>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,13 @@
-// LIB-01 fix: validate API_BASE is defined when set to a non-empty value
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+// LIB-01 fix: validate API_BASE is defined when set to a non-empty value.
+//
+// Env var name aligns with .env.local (`NEXT_PUBLIC_FAULTRAY_API_URL`).
+// A legacy `NEXT_PUBLIC_API_URL` is still honored as a fallback so existing
+// deploys and CI envs keep working through the rename rollout; new code
+// should set only NEXT_PUBLIC_FAULTRAY_API_URL.
+const API_BASE =
+  process.env.NEXT_PUBLIC_FAULTRAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 
 interface ApiOptions {
   method?: string;


### PR DESCRIPTION
## Summary

Phase 1 Tier 2 fix for two issues surfaced in the FaultRay Phase 0 baseline report (https://github.com/mattyopon/faultray/blob/main/docs/phase0-validation-report.md, Task 6, 2026-04-17):

1. **Env-var name mismatch** — `.env.local` set `NEXT_PUBLIC_FAULTRAY_API_URL`, but `src/lib/api.ts:2` and `src/app/reports/page.tsx:146` read the non-existent `NEXT_PUBLIC_API_URL`. As a result `API_BASE` collapsed to `""`, routing every business-logic API call back into the Next.js server itself — which returns 404 for `/api/analysis`, `/api/finance`, `/api/v1/graph-data`, `/api/simulate`.

2. **/whatif silent hardcoded fallback** — the catch block of `runAnalysis()` fabricated `baseline: { overall_score: 85.2 }` and derived the modified score from a `1.5× delta` heuristic. The UI appeared to work even when the backend was entirely unreachable, hiding #1 from users.

## Fix

- `src/lib/api.ts`: read `NEXT_PUBLIC_FAULTRAY_API_URL` first, fall back to `NEXT_PUBLIC_API_URL` for backwards compat during the rename, then `""`.
- `src/app/reports/page.tsx`: same precedence for the HTML report download.
- `src/app/whatif/page.tsx`: remove the fabricated fallback; surface an explicit "Backend unreachable" error Card that tells the user to check `NEXT_PUBLIC_FAULTRAY_API_URL` + the API service.

## Out of scope (follow-up PR)

Wiring `/api/analysis`, `/api/finance`, `/api/v1/graph-data`, `/api/simulate` in Next.js (either as proxy route handlers pointing at the Python FastAPI in the `faultray` repo, or as native Next.js routes). The Phase 0 report flagged them as 404. That needs an architecture decision (proxy vs native) — intentionally not bundled here.

## Verification

- `npx tsc --noEmit` → clean
- `npm run lint` → clean
- `npm run test:unit` → pre-existing rolldown binding failure unrelated to these changes (see node_modules state)

## Test plan

- [x] TypeScript compiles
- [x] ESLint clean
- [ ] Full CI (triggered by this PR)
- [ ] Manual: with `NEXT_PUBLIC_FAULTRAY_API_URL` unset, /whatif now shows the "Backend unreachable" Card instead of fabricated scores

---
🤖 Generated with Claude Code

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
