### PR TITLE
fix(db): add 'starter' to profiles/teams plan CHECK constraint (#24)

### DIFF
--- a/supabase/migrations/005_plan_starter.sql
+++ b/supabase/migrations/005_plan_starter.sql
@@ -11,22 +11,34 @@
 --         updateUserPlan が例外を投げる → サイレントに plan 更新に失敗する。
 --
 -- 実装:
---   001_initial_schema.sql の CHECK はインライン無名制約のため
---   Postgres が自動生成した名前 (通常 <table>_<column>_check) で削除する。
---   環境差異に備えて DO block 内で pg_constraint から実名を取得して DROP する。
+--   001_initial_schema.sql の CHECK は無名 inline 制約であり、Postgres が
+--   自動生成した名前 (<table>_<column>_check 規則) で確定的に命名される。
+--   profiles.plan → profiles_plan_check / teams.plan → teams_plan_check。
+--
+--   念のため、過去 migration で別名の CHECK が付与されている環境に備え
+--   pg_constraint を走査する冪等ガードも併用する。
 -- ============================================================
 
 -- profiles.plan ───────────────────────────────────────────────
+-- 1) Postgres 自動命名 (確定) の名前で drop
+alter table public.profiles
+  drop constraint if exists profiles_plan_check;
+
+-- 2) 別名で付与されている可能性があるケースに備えた冪等ガード
+--    (「plan カラムの CHECK」を厳密に特定)
 do $$
 declare
   c record;
 begin
   for c in
-    select conname
-    from pg_constraint
-    where conrelid = 'public.profiles'::regclass
-      and contype = 'c'
-      and pg_get_constraintdef(oid) ilike '%plan%in%'
+    select con.conname
+    from pg_constraint con
+    join pg_attribute att
+      on att.attrelid = con.conrelid
+     and att.attnum = any(con.conkey)
+    where con.conrelid = 'public.profiles'::regclass
+      and con.contype = 'c'
+      and att.attname = 'plan'
   loop
     execute format('alter table public.profiles drop constraint %I', c.conname);
   end loop;
@@ -37,16 +49,22 @@ alter table public.profiles
   check (plan in ('free', 'starter', 'pro', 'business'));
 
 -- teams.plan ──────────────────────────────────────────────────
+alter table public.teams
+  drop constraint if exists teams_plan_check;
+
 do $$
 declare
   c record;
 begin
   for c in
-    select conname
-    from pg_constraint
-    where conrelid = 'public.teams'::regclass
-      and contype = 'c'
-      and pg_get_constraintdef(oid) ilike '%plan%in%'
+    select con.conname
+    from pg_constraint con
+    join pg_attribute att
+      on att.attrelid = con.conrelid
+     and att.attnum = any(con.conkey)
+    where con.conrelid = 'public.teams'::regclass
+      and con.contype = 'c'
+      and att.attname = 'plan'
   loop
     execute format('alter table public.teams drop constraint %I', c.conname);
   end loop;

--- a/supabase/migrations/005_plan_starter.sql
+++ b/supabase/migrations/005_plan_starter.sql
@@ -1,0 +1,57 @@
+-- ============================================================
+-- Fix #24: profiles.plan / teams.plan CHECK に 'starter' を追加
+--
+-- 背景:
+--   src/lib/types.ts:36 と src/app/api/stripe/webhook/route.ts:8 で
+--   PlanTier = "free" | "starter" | "pro" | "business" と定義されているが、
+--   001_initial_schema.sql の CHECK 制約には 'starter' が含まれていなかった。
+--
+--   結果: Stripe Starter price を契約したユーザーの webhook で
+--         profiles.plan='starter' を書き込もうとすると Postgres CHECK 違反となり
+--         updateUserPlan が例外を投げる → サイレントに plan 更新に失敗する。
+--
+-- 実装:
+--   001_initial_schema.sql の CHECK はインライン無名制約のため
+--   Postgres が自動生成した名前 (通常 <table>_<column>_check) で削除する。
+--   環境差異に備えて DO block 内で pg_constraint から実名を取得して DROP する。
+-- ============================================================
+
+-- profiles.plan ───────────────────────────────────────────────
+do $$
+declare
+  c record;
+begin
+  for c in
+    select conname
+    from pg_constraint
+    where conrelid = 'public.profiles'::regclass
+      and contype = 'c'
+      and pg_get_constraintdef(oid) ilike '%plan%in%'
+  loop
+    execute format('alter table public.profiles drop constraint %I', c.conname);
+  end loop;
+end $$;
+
+alter table public.profiles
+  add constraint profiles_plan_check
+  check (plan in ('free', 'starter', 'pro', 'business'));
+
+-- teams.plan ──────────────────────────────────────────────────
+do $$
+declare
+  c record;
+begin
+  for c in
+    select conname
+    from pg_constraint
+    where conrelid = 'public.teams'::regclass
+      and contype = 'c'
+      and pg_get_constraintdef(oid) ilike '%plan%in%'
+  loop
+    execute format('alter table public.teams drop constraint %I', c.conname);
+  end loop;
+end $$;
+
+alter table public.teams
+  add constraint teams_plan_check
+  check (plan in ('free', 'starter', 'pro', 'business'));


### PR DESCRIPTION
## Summary
- `profiles.plan` / `teams.plan` の CHECK 制約に `'starter'` を追加
- `PlanTier` 型定義 (`'free' | 'starter' | 'pro' | 'business'`) と DB schema の乖離を解消
- Closes #24

## 背景
`src/lib/types.ts:36` と `src/app/api/stripe/webhook/route.ts:8-14,116` で Starter 価格帯が `PlanTier` として正式に定義されているが、`001_initial_schema.sql:13,24` の CHECK 制約には `'starter'` が含まれていなかった。

結果として Stripe Starter price を契約したユーザーの webhook で `updateUserPlan(userId, 'starter', 'active')` が呼ばれると Postgres CHECK 違反で例外が発生し、profile.plan が `'free'` のまま残る (revenue-critical silent failure)。

## 実装
- DO block で `pg_constraint` から既存の無名 CHECK 制約を実名で取得し DROP
- 新しい CHECK を `profiles_plan_check` / `teams_plan_check` の明示的名前で再定義
- 環境差 (何度か migrate 済みなど) で制約名が変わっていても動作する冪等性を確保

## Test plan
- [ ] Supabase ローカルで migration 適用成功を確認
- [ ] `profiles` に `plan='starter'` を INSERT/UPDATE できる
- [ ] `plan='invalid'` は依然 CHECK violation になる
- [ ] 既存の `'free' | 'pro' | 'business'` レコードに影響なし
- [ ] webhook e2e: Starter price の checkout.session.completed で plan が 'starter' に更新される

## Rollback
`005_plan_starter.sql` を revert し、元の CHECK (`'free','pro','business'` のみ) に戻す migration を追加で流す。既存 'starter' レコードがあれば先に 'free' 等へ migrate 必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for a new "starter" plan tier, expanding plan options for users and team accounts alongside existing free, pro, and business tiers.

* **Chores**
  * Updated database infrastructure to accommodate the new plan tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->