### PR TITLE
fix(billing): replace Stripe webhook `as any` with typed helper (#31)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -147,14 +151,14 @@
         "filename": "src/app/api/stripe/webhook/route.ts",
         "hashed_secret": "6dc93fd5dfc39087aedf8cdc970dcd814aaffed9",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 98
       },
       {
         "type": "Secret Keyword",
         "filename": "src/app/api/stripe/webhook/route.ts",
         "hashed_secret": "e3ce06b48b5e21fad3402189e4ba16dfa5a481a1",
         "is_verified": false,
-        "line_number": 75
+        "line_number": 100
       }
     ],
     "src/app/audit-log/page.tsx": [
@@ -465,5 +469,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-10T02:24:13Z"
+  "generated_at": "2026-04-22T04:52:24Z"
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -7,6 +7,31 @@ export const dynamic = "force-dynamic";
 
 type PlanTier = "free" | "starter" | "pro" | "business";
 
+/**
+ * Stripe Invoice extension (#31):
+ * - `parent.subscription_details.subscription` exists on Stripe API v2+
+ *   invoice objects where the invoice parents a subscription. The
+ *   official Stripe TS type does not yet expose this nested field.
+ * - `subscription` is the legacy top-level field (Stripe API v1 /
+ *   historical invoices) still occasionally present on retrieved objects.
+ *
+ * We extract a `subscriptionId` via a single narrow helper instead of
+ * scattering `as any` casts across the file.
+ */
+type InvoiceWithSubscription = Stripe.Invoice & {
+  parent?: {
+    subscription_details?: {
+      subscription?: string | null;
+    } | null;
+  } | null;
+  subscription?: string | null;
+};
+
+function extractSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const inv = invoice as InvoiceWithSubscription;
+  return inv.parent?.subscription_details?.subscription ?? inv.subscription ?? null;
+}
+
 function planTierFromPriceId(priceId: string): PlanTier | null {
   const starterPriceIds = (process.env.STRIPE_STARTER_PRICE_IDS || "").split(",").filter(Boolean);
   const proPriceIds = (process.env.STRIPE_PRO_PRICE_IDS || "").split(",").filter(Boolean);
@@ -176,12 +201,8 @@ export async function POST(request: Request) {
           // planをpriceIdから解決する。subscriptionが取得できない場合は
           // 既存のplanを維持するためupdateUserByCustomerIdのplan引数は使わず、
           // subscription取得後に実際のpriceIdからplanを決定する。
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const invoiceAny = invoice as any;
-          const subscriptionId: string | null =
-            invoiceAny.parent?.subscription_details?.subscription ??
-            invoiceAny.subscription ??
-            null;
+          // NOTE (#31): replaced `as any` cast with InvoiceWithSubscription.
+          const subscriptionId: string | null = extractSubscriptionId(invoice);
 
           let resolvedPlan: PlanTier = "pro"; // fallback
           if (subscriptionId) {
@@ -204,13 +225,9 @@ export async function POST(request: Request) {
       case "invoice.payment_succeeded": {
         const invoice = event.data.object as Stripe.Invoice;
         const customerId = invoice.customer as string;
-        // Extract subscription id from parent (Stripe API v2+) or legacy field
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const invoiceAny = invoice as any;
-        const subscriptionId: string | null =
-          invoiceAny.parent?.subscription_details?.subscription ??
-          invoiceAny.subscription ??
-          null;
+        // Extract subscription id from parent (Stripe API v2+) or legacy field.
+        // NOTE (#31): replaced `as any` cast with InvoiceWithSubscription.
+        const subscriptionId: string | null = extractSubscriptionId(invoice);
         // Only act on subscription invoices (not one-time charges)
         if (subscriptionId) {
           // Retrieve subscription to determine plan

--- a/tests/unit/stripe-webhook-no-any.test.ts
+++ b/tests/unit/stripe-webhook-no-any.test.ts
@@ -1,0 +1,42 @@
+/**
+ * L2 Regression: Stripe webhook should not contain `as any` casts (#31).
+ *
+ * Before #31 the webhook used `invoice as any` in two places to reach
+ * `parent.subscription_details.subscription`. That erased Stripe SDK
+ * typing and was flagged P2 by the codebase review (#31). This test
+ * locks in the refactor (InvoiceWithSubscription + extractSubscriptionId)
+ * by asserting no `as any` escape hatches remain in the webhook source.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const WEBHOOK_PATH = resolve(
+  __dirname,
+  "../../src/app/api/stripe/webhook/route.ts"
+);
+
+describe("L2: stripe webhook type safety (#31)", () => {
+  it("contains no `as any` casts in executable code", () => {
+    const src = readFileSync(WEBHOOK_PATH, "utf-8");
+    // Strip block and line comments so the test does not false-positive on
+    // explanatory text that legitimately mentions `as any`.
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|\s)\/\/.*$/gm, "");
+    const matches = stripped.match(/\bas\s+any\b/g) ?? [];
+    expect(matches, `found ${matches.length} \`as any\` cast(s) in webhook code`).toHaveLength(0);
+  });
+
+  it("contains no @ts-ignore / @ts-nocheck directives", () => {
+    const src = readFileSync(WEBHOOK_PATH, "utf-8");
+    // Include directives are only valid in comments, so scan raw source.
+    expect(/@ts-ignore|@ts-nocheck/.test(src), "webhook should have no @ts-ignore / @ts-nocheck").toBe(false);
+  });
+
+  it("exposes the InvoiceWithSubscription helper + extractSubscriptionId", () => {
+    const src = readFileSync(WEBHOOK_PATH, "utf-8");
+    expect(src).toMatch(/type\s+InvoiceWithSubscription\b/);
+    expect(src).toMatch(/function\s+extractSubscriptionId\b/);
+  });
+});


### PR DESCRIPTION
Stripe Invoice の `parent.subscription_details.subscription` (Stripe API v2+ の nested field、公式 TS 型未公開) にアクセスするため 2 箇所で `invoice as any` を使用していた型安全性の問題を修正。

## 変更
- `InvoiceWithSubscription` 型 (narrow extend) + `extractSubscriptionId` ヘルパーを追加
- webhook.ts 内 2 callsite を置換
- `tests/unit/stripe-webhook-no-any.test.ts` で regression lock (3 ケース)

## Test plan
- [ ] CI Vitest 225/225 (+3 new)
- [ ] tsc --noEmit error 0 (ローカル確認済)

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
