### PR TITLE
chore: add Dependabot + NOTICE + Research Prototype disclaimer (#40, #42, #44)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+# Dependabot config for faultray-app (#42)
+# core repo (faultray) tracks pip/github-actions/docker; here we track
+# npm (Next.js app) + github-actions. No Python, no Docker.
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    # Group dev dependencies into a single PR so security noise stays low.
+    # Runtime deps (Next.js / React / Supabase / Stripe) ship individual PRs
+    # for visibility.
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+    # Require Dependabot to use conventional commit prefix
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,59 @@
+FaultRay SaaS (faultray-app)
+Copyright 2025-2026 Yutaro Maeda and FaultRay Contributors
+
+This product is licensed under the Apache License, Version 2.0 (see LICENSE).
+
+────────────────────────────────────────────────────────────────────────────
+Third-Party Notices (#40)
+────────────────────────────────────────────────────────────────────────────
+
+This product includes the following third-party open-source components.
+Each is used under its respective license. Full license texts are
+available from the linked repositories.
+
+Runtime dependencies
+────────────────────
+
+| Component                    | License   | Source                                                           |
+|------------------------------|-----------|------------------------------------------------------------------|
+| Next.js                      | MIT       | https://github.com/vercel/next.js                                |
+| React, React DOM             | MIT       | https://github.com/facebook/react                                |
+| Tailwind CSS                 | MIT       | https://github.com/tailwindlabs/tailwindcss                      |
+| @tailwindcss/postcss         | MIT       | https://github.com/tailwindlabs/tailwindcss                      |
+| @supabase/ssr                | MIT       | https://github.com/supabase/ssr                                  |
+| @supabase/supabase-js        | MIT       | https://github.com/supabase/supabase-js                          |
+| Stripe Node SDK              | MIT       | https://github.com/stripe/stripe-node                            |
+| lucide-react                 | ISC       | https://github.com/lucide-icons/lucide                           |
+| clsx                         | MIT       | https://github.com/lukeed/clsx                                   |
+| tailwind-merge               | MIT       | https://github.com/dcastil/tailwind-merge                        |
+| server-only                  | MIT       | https://github.com/vercel/next.js (internal pkg)                 |
+
+Development dependencies
+────────────────────────
+
+| Component                    | License   | Source                                                           |
+|------------------------------|-----------|------------------------------------------------------------------|
+| TypeScript                   | Apache-2.0| https://github.com/microsoft/TypeScript                          |
+| ESLint                       | MIT       | https://github.com/eslint/eslint                                 |
+| eslint-config-next           | MIT       | https://github.com/vercel/next.js                                |
+| Vite                         | MIT       | https://github.com/vitejs/vite                                   |
+| @vitejs/plugin-react         | MIT       | https://github.com/vitejs/vite-plugin-react                      |
+| Vitest                       | MIT       | https://github.com/vitest-dev/vitest                             |
+| @testing-library/react       | MIT       | https://github.com/testing-library/react-testing-library         |
+| @testing-library/jest-dom    | MIT       | https://github.com/testing-library/jest-dom                      |
+| jsdom                        | MIT       | https://github.com/jsdom/jsdom                                   |
+| Playwright                   | Apache-2.0| https://github.com/microsoft/playwright                          |
+| @rolldown/binding-linux-x64  | MIT       | https://github.com/rolldown-rs/rolldown                          |
+| @types/*                     | MIT       | https://github.com/DefinitelyTyped/DefinitelyTyped               |
+
+Regeneration
+────────────
+
+This NOTICE is generated from `package.json` dependencies. To refresh:
+
+  npx license-checker --production --json > /tmp/licenses.json
+  # review and update the table above with any added / removed packages
+
+See the license audit workflow (faultray/#97) for automated SPDX
+enforcement of the server-side Python stack. A parallel npm audit for
+this repo is tracked in a follow-up issue.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # FaultRay SaaS — Next.js Frontend
 
+> ⚠️ **Research Prototype — not a certified compliance tool.**
+> FaultRay is under active research. Outputs (resilience score, compliance
+> mappings to SOC 2 / ISO 27001 / PCI DSS / DORA) are **theoretical
+> estimates** from the topology you declare, not substitutes for formal
+> regulatory audit or runtime chaos engineering. See the [core repo README](https://github.com/mattyopon/faultray#research-prototype)
+> for validation-maturity details.
+
 The web application for [faultray.com](https://faultray.com) — pre-deployment resilience simulation SaaS (research prototype) that estimates your system's structural availability ceiling from declared topology, without touching production.
 
 > **Try it now**: [faultray.com](https://faultray.com) — Free tier, no credit card required.

--- a/tests/unit/readme-disclaimer.test.ts
+++ b/tests/unit/readme-disclaimer.test.ts
@@ -1,0 +1,33 @@
+/**
+ * L2 Regression: README + NOTICE structure (#40, #44).
+ */
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "../..");
+
+describe("L2: README disclaimer + NOTICE file", () => {
+  it("README has prominent Research Prototype disclaimer block (#44)", () => {
+    const readme = readFileSync(resolve(ROOT, "README.md"), "utf-8");
+    // Must contain a blockquote (> ...) AND the phrase "Research Prototype"
+    // with warning / ⚠️ emoji to catch the eye.
+    expect(readme).toMatch(/^>\s+.*Research Prototype/mi);
+    expect(readme).toMatch(/not a certified/i);
+  });
+
+  it("NOTICE file exists with third-party attribution (#40)", () => {
+    const noticePath = resolve(ROOT, "NOTICE");
+    expect(existsSync(noticePath)).toBe(true);
+
+    const notice = readFileSync(noticePath, "utf-8");
+    expect(notice).toMatch(/Copyright .* Yutaro Maeda/);
+    expect(notice).toMatch(/Apache License/);
+    expect(notice).toMatch(/Third-Party Notices/);
+
+    // Sanity: at least a handful of known deps appear in the table.
+    for (const lib of ["Next.js", "React", "Stripe", "Tailwind"]) {
+      expect(notice).toContain(lib);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
関連する 3 件の小さな chores を 1 PR に集約。

### #42 Dependabot for app
core repo には `.github/dependabot.yml` があるが app 側が未設定だった。npm CVE の自動追跡が働いていなかった問題を解消。
- `.github/dependabot.yml` 新規 (npm weekly + github-actions weekly)
- dev deps を group PR 化 / commit prefix を conventional に

### #40 NOTICE (Apache-2.0 attribution)
Apache-2.0 採用しているが third-party attribution ファイルが欠落していた義務違反を解消。
- `NOTICE` 新規: Next.js / React / Stripe / Supabase 等の主要 deps 対応表 (MIT/ISC/Apache)
- 再生成手順 (`npx license-checker`) も記載

### #44 Research Prototype disclaimer
既存 README の本文中記載は見落としやすいため独立警告ブロックに昇格。
- README 冒頭に `⚠️ Research Prototype — not a certified compliance tool` の blockquote を追加
- core repo README の validation-maturity セクションへ link

## Regression lock
`tests/unit/readme-disclaimer.test.ts` (2 ケース):
- README に "Research Prototype" + "not a certified" が残存
- NOTICE ファイル存在 + Apache License + 主要 deps (Next.js/React/Stripe/Tailwind) 言及

Closes #40, #42, #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added research prototype disclaimer to README clarifying that compliance mappings are theoretical estimates, not substitutes for formal audits.
  * Added third-party licensing notices document enumerating project dependencies and their license types.

* **Chores**
  * Configured automated weekly dependency updates for npm packages and GitHub Actions workflows with pull request limits.

* **Tests**
  * Added validation tests for licensing documentation and README disclaimer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->