### PR TITLE
fix(db): atomic account deletion via SECURITY DEFINER RPC (#29)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -133,7 +129,7 @@
         "filename": "src/app/api/account/delete/route.ts",
         "hashed_secret": "6dc93fd5dfc39087aedf8cdc970dcd814aaffed9",
         "is_verified": false,
-        "line_number": 99
+        "line_number": 103
       }
     ],
     "src/app/api/stripe/checkout/route.ts": [
@@ -469,5 +465,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-22T04:52:24Z"
+  "generated_at": "2026-04-23T08:54:51Z"
 }

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -62,72 +62,64 @@ export async function DELETE(request: Request) {
   const admin = createAdminClient(supabaseUrl, serviceRoleKey);
 
   try {
-    // 1. Delete data for teams owned by this user only.
-    //    Teams where the user is merely a member must NOT be deleted.
-    const { data: ownedTeams } = await admin
-      .from("teams")
-      .select("id")
-      .eq("owner_id", userId);
+    // 1. Pre-read stripe_customer_id BEFORE the atomic delete (#29).
+    //    The RPC in step 2 will wipe the profile row, so we must capture
+    //    external-system identifiers ahead of time.
+    const { data: profile } = await admin
+      .from("profiles")
+      .select("stripe_customer_id")
+      .eq("id", userId)
+      .maybeSingle();
+    const stripeCustomerId =
+      (profile?.stripe_customer_id as string | null | undefined) ?? null;
 
-    if (ownedTeams && ownedTeams.length > 0) {
-      const ownedTeamIds = ownedTeams.map((t: { id: string }) => t.id);
-
-      // Delete simulation runs
-      await admin.from("simulation_runs").delete().in("team_id", ownedTeamIds);
-
-      // Delete usage records
-      await admin.from("usage").delete().in("team_id", ownedTeamIds);
-
-      // Delete billing events
-      await admin.from("billing_events").delete().in("team_id", ownedTeamIds);
-
-      // Delete projects
-      await admin.from("projects").delete().in("team_id", ownedTeamIds);
-
-      // Remove all members from owned teams before deleting the teams
-      await admin.from("team_members").delete().in("team_id", ownedTeamIds);
-
-      // Delete teams owned by this user
-      await admin.from("teams").delete().eq("owner_id", userId);
+    // 2. Atomic DB deletion via SECURITY DEFINER RPC (#29).
+    //    Replaces a 7-step non-transactional sequence that could leave
+    //    orphan rows on failure. The RPC wraps the whole cascade in a
+    //    single PL/pgSQL transaction and returns per-table counts.
+    const { error: rpcError } = await admin.rpc("delete_user_account", {
+      uid: userId,
+    });
+    if (rpcError) {
+      console.error(
+        "[account/delete] delete_user_account RPC failed:",
+        rpcError.message
+      );
+      return NextResponse.json(
+        { error: "Account deletion failed. Please contact support." },
+        { status: 500 }
+      );
     }
 
-    // Remove this user's membership from teams they joined but do not own
-    await admin.from("team_members").delete().eq("user_id", userId);
-
-    // 2. Cancel Stripe subscriptions to prevent continued billing after account deletion
+    // 3. Cancel Stripe subscriptions using the pre-read customer id.
+    //    External call — deliberately outside the DB tx. Failure is
+    //    logged but non-fatal (data cleanup has already succeeded;
+    //    Stripe customer.subscription.deleted webhook will eventually
+    //    reconcile).
     const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-    if (stripeSecretKey && stripeSecretKey !== "sk_test_placeholder") {
+    if (
+      stripeCustomerId &&
+      stripeSecretKey &&
+      stripeSecretKey !== "sk_test_placeholder"
+    ) {
       try {
         const stripe = new Stripe(stripeSecretKey, { timeout: 30000 });
-
-        // Fetch stripe_customer_id from profiles before deletion
-        const { data: profile } = await admin
-          .from("profiles")
-          .select("stripe_customer_id")
-          .eq("id", userId)
-          .maybeSingle();
-
-        const customerId = profile?.stripe_customer_id as string | null | undefined;
-        if (customerId) {
-          const subscriptions = await stripe.subscriptions.list({ customer: customerId });
-          await Promise.all(
-            subscriptions.data.map((sub) => stripe.subscriptions.cancel(sub.id))
-          );
-          console.info(
-            `[account/delete] Cancelled ${subscriptions.data.length} Stripe subscription(s) for customer ${customerId}`
-          );
-        }
+        const subscriptions = await stripe.subscriptions.list({
+          customer: stripeCustomerId,
+        });
+        await Promise.all(
+          subscriptions.data.map((sub) => stripe.subscriptions.cancel(sub.id))
+        );
+        console.info(
+          `[account/delete] Cancelled ${subscriptions.data.length} Stripe subscription(s) for customer ${stripeCustomerId}`
+        );
       } catch (stripeErr) {
-        // Log but do not block account deletion — data cleanup takes priority
         const msg = stripeErr instanceof Error ? stripeErr.message : "Unknown error";
         console.error("[account/delete] Stripe cancellation error (non-fatal):", msg);
       }
     }
 
-    // 3. Delete / anonymize the user profile
-    await admin.from("profiles").delete().eq("id", userId);
-
-    // 4. Delete the auth user (point-of-no-return)
+    // 4. Delete the auth user (point-of-no-return, external to DB tx)
     const { error: deleteAuthError } = await admin.auth.admin.deleteUser(userId);
     if (deleteAuthError) {
       // Log but do not expose internal error details

--- a/supabase/migrations/008_account_delete_atomic.sql
+++ b/supabase/migrations/008_account_delete_atomic.sql
@@ -1,0 +1,95 @@
+-- ============================================================
+-- Fix #29: atomic account deletion via PL/pgSQL SECURITY DEFINER function
+--
+-- 背景:
+--   /api/account/delete は profiles/teams/team_members/projects/
+--   simulation_runs/usage/billing_events を順次 delete していたが、
+--   Supabase JS client に明示的 tx API が無いため、中途で失敗すると
+--   orphan row (ex. team が残って team_members だけ消える) が発生し、
+--   復旧が customer support 案件化するリスクがあった。GDPR 削除要求
+--   の compliance 観点でも問題。
+--
+-- 対処:
+--   set-based で全テーブルを 1 tx 内で削除する SECURITY DEFINER 関数を
+--   定義し、API route から RPC 1 回で呼び出す。
+--
+--   関数の中身は (1) ownedTeams の id を取得、(2) 依存テーブルを
+--   一括 delete、(3) team_members membership 解除、(4) profile 削除、
+--   までを atomic に実行し、削除件数を返す。
+--
+--   auth.users と Stripe subscription は外部サービスなので、DB tx の
+--   外側で route が個別 cancel する (現状維持)。
+-- ============================================================
+
+create or replace function public.delete_user_account(uid uuid)
+returns table (
+  teams_deleted integer,
+  runs_deleted integer,
+  projects_deleted integer,
+  memberships_deleted integer,
+  profile_deleted integer
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  owned_team_ids uuid[];
+  v_runs int := 0;
+  v_projects int := 0;
+  v_teams int := 0;
+  v_members int := 0;
+  v_profile int := 0;
+begin
+  -- 1) ownedTeams を array で取得
+  select coalesce(array_agg(id), '{}'::uuid[])
+    into owned_team_ids
+  from public.teams
+  where owner_id = uid;
+
+  if array_length(owned_team_ids, 1) is not null then
+    -- simulation_runs / usage / billing_events はすべて team_id で
+    -- cascade 削除できるテーブル。明示的に delete して count を返す。
+    delete from public.simulation_runs
+      where team_id = any(owned_team_ids);
+    get diagnostics v_runs = row_count;
+
+    delete from public.usage
+      where team_id = any(owned_team_ids);
+
+    delete from public.billing_events
+      where team_id = any(owned_team_ids);
+
+    delete from public.projects
+      where team_id = any(owned_team_ids);
+    get diagnostics v_projects = row_count;
+
+    -- 所有 team の全 membership を削除
+    delete from public.team_members
+      where team_id = any(owned_team_ids);
+    get diagnostics v_members = row_count;
+
+    -- team 本体
+    delete from public.teams
+      where id = any(owned_team_ids);
+    get diagnostics v_teams = row_count;
+  end if;
+
+  -- 2) 自分が join している他人の team の membership も削除
+  delete from public.team_members
+    where user_id = uid;
+  -- (v_members は既に owned 分だけ数えている。join 先 membership は
+  --  別カウントにするほどの情報価値がないので合算しない)
+
+  -- 3) profile 削除 (ON DELETE CASCADE で auth.users から降ってくる
+  --    削除より先に能動的に実行)
+  delete from public.profiles where id = uid;
+  get diagnostics v_profile = row_count;
+
+  return query select v_teams, v_runs, v_projects, v_members, v_profile;
+end;
+$$;
+
+-- service_role からのみ呼び出せるよう権限を明示的に絞る
+revoke all on function public.delete_user_account(uuid) from public;
+grant execute on function public.delete_user_account(uuid) to service_role;

--- a/tests/unit/account-delete-atomic.test.ts
+++ b/tests/unit/account-delete-atomic.test.ts
@@ -1,0 +1,174 @@
+/**
+ * L2 Regression: /api/account/delete uses atomic RPC + preserves Stripe cancel (#29).
+ *
+ * Locks in the refactor:
+ * - Single `rpc("delete_user_account", { uid })` replaces the 7-step
+ *   non-transactional sequence.
+ * - stripe_customer_id is read *before* the RPC so Stripe cancellation
+ *   still has its handle after the DB row is gone.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/rate-limit", () => ({
+  applyRateLimit: () => undefined,
+}));
+
+// Stub supabase/server (SSR client for auth.getUser)
+const _mockUser = { id: "user-abc-123" };
+let _getUserOverride: { user: typeof _mockUser | null; error: { message: string } | null } = {
+  user: _mockUser,
+  error: null,
+};
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: _getUserOverride.user },
+        error: _getUserOverride.error,
+      }),
+    },
+  }),
+}));
+
+// Stub Stripe SDK
+const _mockStripeList = vi.fn();
+const _mockStripeCancel = vi.fn();
+vi.mock("stripe", () => {
+  class StripeStub {
+    subscriptions = {
+      list: _mockStripeList,
+      cancel: _mockStripeCancel,
+    };
+    constructor(..._args: unknown[]) {}
+  }
+  return { default: StripeStub };
+});
+
+// Stub supabase-js admin client
+let _profileRow: { stripe_customer_id: string | null } | null = {
+  stripe_customer_id: "cus_test_abc",
+};
+let _rpcError: { message: string } | null = null;
+let _deleteAuthError: { message: string } | null = null;
+const _rpcCalls: Array<{ fn: string; args: unknown }> = [];
+const _profileSelectCalls: Array<{ eq: string }> = [];
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (_table: string) => {
+      return {
+        select: (_cols: string) => ({
+          eq: (_col: string, val: string) => ({
+            maybeSingle: async () => {
+              _profileSelectCalls.push({ eq: val });
+              return { data: _profileRow, error: null };
+            },
+          }),
+        }),
+      };
+    },
+    rpc: async (fn: string, args: unknown) => {
+      _rpcCalls.push({ fn, args });
+      return { error: _rpcError };
+    },
+    auth: {
+      admin: {
+        deleteUser: async (_id: string) => ({ error: _deleteAuthError }),
+      },
+    },
+  }),
+}));
+
+describe("L2: /api/account/delete — atomic RPC + Stripe preserve (#29)", () => {
+  const ORIG_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    _getUserOverride = { user: _mockUser, error: null };
+    _profileRow = { stripe_customer_id: "cus_test_abc" };
+    _rpcError = null;
+    _deleteAuthError = null;
+    _rpcCalls.length = 0;
+    _profileSelectCalls.length = 0;
+    _mockStripeList.mockReset();
+    _mockStripeCancel.mockReset();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";  // pragma: allowlist secret
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";  // pragma: allowlist secret
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function invoke(body: unknown = { confirm: true }) {
+    const { DELETE } = await import("@/app/api/account/delete/route");
+    const req = new Request("https://test.local/api/account/delete", {
+      method: "DELETE",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await DELETE(req);
+    const respBody = (await res.json()) as Record<string, unknown>;
+    return { status: res.status, body: respBody };
+  }
+
+  it("requires { confirm: true } (400 otherwise)", async () => {
+    const { status } = await invoke({});
+    expect(status).toBe(400);
+  });
+
+  it("401 when not authenticated", async () => {
+    _getUserOverride = { user: null, error: { message: "no session" } };
+    const { status } = await invoke();
+    expect(status).toBe(401);
+  });
+
+  it("calls the atomic RPC with the user id and cancels Stripe subs", async () => {
+    _mockStripeList.mockResolvedValue({
+      data: [{ id: "sub_1" }, { id: "sub_2" }],
+    });
+    _mockStripeCancel.mockResolvedValue({});
+
+    const { status, body } = await invoke();
+    expect(status).toBe(200);
+    expect(body).toEqual({ deleted: true });
+
+    // Exactly one RPC call with the right shape
+    expect(_rpcCalls).toEqual([
+      { fn: "delete_user_account", args: { uid: _mockUser.id } },
+    ]);
+    // Profile was read before the RPC (for stripe_customer_id)
+    expect(_profileSelectCalls).toEqual([{ eq: _mockUser.id }]);
+    // Both subscriptions cancelled
+    expect(_mockStripeCancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 when the RPC fails (and does NOT hit Stripe)", async () => {
+    _rpcError = { message: "unique_violation" };
+
+    const { status } = await invoke();
+    expect(status).toBe(500);
+    expect(_mockStripeCancel).not.toHaveBeenCalled();
+  });
+
+  it("Stripe error is non-fatal (deletion still succeeds)", async () => {
+    _mockStripeList.mockRejectedValue(new Error("Stripe API down"));
+
+    const { status, body } = await invoke();
+    expect(status).toBe(200);
+    expect(body.deleted).toBe(true);
+  });
+
+  it("skips Stripe when stripe_customer_id is null", async () => {
+    _profileRow = { stripe_customer_id: null };
+
+    const { status, body } = await invoke();
+    expect(status).toBe(200);
+    expect(body.deleted).toBe(true);
+    expect(_mockStripeList).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`/api/account/delete` の 7 step 非 tx sequence を atomic RPC に置換し GDPR compliance gap を解消。

## 変更
- `supabase/migrations/008_account_delete_atomic.sql` — `delete_user_account(uid)` SECURITY DEFINER 関数 (全テーブル 1 tx)
- `route.ts` — stripe_customer_id を **RPC 前に pre-read** → Stripe cancel 維持 + `rpc("delete_user_account", {uid})` 1 回呼出
- `tests/unit/account-delete-atomic.test.ts` — 6 regression (confirm 必須 / 401 / RPC 呼出 / 500 / Stripe non-fatal / customer_id null)

## Self-review
初稿で Stripe cancel ブロックを丸ごと削除してしまい regression。pre-read + 明示 order に修正。

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now executes reliably as a single atomic transaction, ensuring all related data is removed consistently and preventing partial deletions.

* **Tests**
  * Added comprehensive test suite for account deletion flow and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->