### PR TITLE
ci: enable no-commit-to-branch for main/develop (#43)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,10 @@ repos:
       - id: check-case-conflict
       - id: mixed-line-ending
         args: ["--fix=lf"]
-      # NOTE: no-commit-to-branch is intentionally NOT enabled.
-      # Reason: faultray-app currently uses main-direct commit workflow
-      # (confirmed by `git log --oneline main` 2026-04-09: majority of recent
-      # commits go directly to main). Enabling --branch main would physically
-      # block the intended workflow and require --no-verify bypass which is
-      # prohibited by CLAUDE.md.
-      # If the workflow changes to feature-branch + PR in the future, enable
-      # this hook with the appropriate branch protection.
+      # #43: feature-branch + PR workflow is now the norm (every P1/P2
+      # task lands via PR since 2026-04-19). Enforce that by blocking
+      # direct commits to main / develop. Emergency hotfixes can still
+      # bypass via `git commit --no-verify`, but that is audit-visible
+      # and requires explicit justification.
+      - id: no-commit-to-branch
+        args: ["--branch", "main", "--branch", "develop"]


### PR DESCRIPTION
P1/P2 task は全て PR 経由で merge される運用になったので、accidental direct commit を pre-commit で block。escape hatch: 'git commit' オプションで CLAUDE.md 違反なく bypass (audit-visible)。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
