### PR TITLE
sec: Upstash ratelimit backend + constant-time cron auth (#25, #27)

### DIFF
--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -14,7 +14,7 @@ import Stripe from "stripe";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(request: Request) {
-  const limited = applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
   // Parse optional confirmation body

--- a/src/app/api/audit-log/route.ts
+++ b/src/app/api/audit-log/route.ts
@@ -20,7 +20,7 @@ const ALLOWED_ACTIONS = new Set([
  * Query params: ?action=LOGIN&outcome=FAILURE&limit=50&offset=0
  */
 export async function GET(request: Request) {
-  const limited = applyRateLimit(request, { limit: 30, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 30, windowMs: 60_000 });
   if (limited) return limited;
 
   const { user, error } = await requireAuth(request);
@@ -73,7 +73,7 @@ export async function GET(request: Request) {
  * Called internally by other API routes when actions occur.
  */
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   const { user, error } = await requireAuth(request);

--- a/src/app/api/coupon/redeem/route.ts
+++ b/src/app/api/coupon/redeem/route.ts
@@ -9,7 +9,7 @@ interface RedeemBody {
 
 export async function POST(request: Request) {
   // API-08: レート制限 — 5 attempts / minute per IP (brute-force protection)
-  const limited = applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
   let body: Partial<RedeemBody>;

--- a/src/app/api/cron/trial-reminders/route.ts
+++ b/src/app/api/cron/trial-reminders/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { sendEmail } from "@/lib/email";
 import { trialReminderEmail } from "@/lib/email-templates";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { verifyCronAuth } from "@/lib/cron-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -9,18 +10,14 @@ export const dynamic = "force-dynamic";
  * POST /api/cron/trial-reminders
  * Called by Vercel Cron or external scheduler (daily).
  * Finds users whose trial ends in exactly 3 days and sends reminder emails.
- * Protected by CRON_SECRET to prevent unauthorized invocation.
+ * Protected by CRON_SECRET + optional CRON_ALLOWED_IPS (#27).
  */
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
-  const cronSecret = process.env.CRON_SECRET;
-  const authHeader = request.headers.get("authorization");
-
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauthorized = verifyCronAuth(request);
+  if (unauthorized) return unauthorized;
 
   const { createClient } = await import("@supabase/supabase-js");
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -16,7 +16,7 @@ const VALID_KEYS = [
  * GET /api/notification-preferences — Read notification settings for the current user.
  */
 export async function GET(request: Request) {
-  const limited = applyRateLimit(request, { limit: 30, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 30, windowMs: 60_000 });
   if (limited) return limited;
 
   const { user, error } = await requireAuth(request);
@@ -50,7 +50,7 @@ export async function GET(request: Request) {
  * Body: { "simulationCompleted": false, "weeklySummary": true }
  */
 export async function PATCH(request: Request) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   const { user, error } = await requireAuth(request);

--- a/src/app/api/notify/slack/route.ts
+++ b/src/app/api/notify/slack/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: Request) {
   if (error) return error;
 
   // API-08: レート制限 — 10 requests / minute per IP
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   let body: Partial<SlackNotifyRequest>;

--- a/src/app/api/org/create/route.ts
+++ b/src/app/api/org/create/route.ts
@@ -8,7 +8,7 @@ interface CreateOrgBody {
 }
 
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   let body: Partial<CreateOrgBody>;

--- a/src/app/api/org/invite/route.ts
+++ b/src/app/api/org/invite/route.ts
@@ -12,7 +12,7 @@ interface InviteBody {
 const VALID_ROLES = ["admin", "member", "viewer"] as const;
 
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   let body: Partial<InviteBody>;

--- a/src/app/api/org/members/route.ts
+++ b/src/app/api/org/members/route.ts
@@ -4,7 +4,7 @@ import { applyRateLimit } from "@/lib/rate-limit";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-  const limited = applyRateLimit(request, { limit: 30, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 30, windowMs: 60_000 });
   if (limited) return limited;
 
   let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -35,7 +35,7 @@ const TRIAL_DAYS: Record<Plan, number | undefined> = {
 };
 
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   const secretKey = process.env.STRIPE_SECRET_KEY;

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -62,7 +62,7 @@ async function updateUserByCustomerId(
 
 export async function POST(request: Request) {
   // Defense-in-depth: generous limit to allow Stripe retries
-  const limited = applyRateLimit(request, { limit: 60, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 60, windowMs: 60_000 });
   if (limited) return limited;
 
   const secretKey = process.env.STRIPE_SECRET_KEY;

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -19,7 +19,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   const { id } = await params;
@@ -125,7 +125,7 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const limited = applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
   const { id } = await params;

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -44,7 +44,7 @@ async function getOrgId(
 }
 
 export async function GET(request: Request) {
-  const limited = applyRateLimit(request, { limit: 30, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 30, windowMs: 60_000 });
   if (limited) return limited;
 
   let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
@@ -84,7 +84,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
   let body: Partial<CreateTaskBody>;

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,63 @@
+/**
+ * Cron endpoint authentication helper (#27).
+ *
+ * Strengthens the Bearer-only check in two ways:
+ *   1. Constant-time comparison against CRON_SECRET to defeat timing-
+ *      based secret extraction (even though single-shot retry limits
+ *      make practical exploitation hard, this closes the theoretical
+ *      gap).
+ *   2. If CRON_ALLOWED_IPS is set (comma-separated CIDR or exact IPs),
+ *      the caller's IP must match. Vercel documents the Cron IP range
+ *      which operators can pin via this env. When unset, IP check is
+ *      skipped (dev / self-hosted compatibility).
+ */
+
+import { NextResponse } from "next/server";
+
+import { getClientIp } from "@/lib/rate-limit";
+
+function _constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function _ipAllowed(clientIp: string): boolean {
+  const allow = (process.env.CRON_ALLOWED_IPS || "").split(",").map((s) => s.trim()).filter(Boolean);
+  if (allow.length === 0) return true; // not configured → permissive
+  // Simple exact match; CIDR support deferred (Vercel publishes exact egress IPs)
+  return allow.includes(clientIp);
+}
+
+/**
+ * Verify a cron endpoint request. Returns a 401 Response if invalid,
+ * null if authorized. Callers should short-circuit on non-null result.
+ */
+export function verifyCronAuth(request: Request): Response | null {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured" },
+      { status: 503 }
+    );
+  }
+
+  const authHeader = request.headers.get("authorization") || "";
+  const expected = `Bearer ${cronSecret}`;
+  if (!_constantTimeEqual(authHeader, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const clientIp = getClientIp(request);
+  if (!_ipAllowed(clientIp)) {
+    return NextResponse.json(
+      { error: "Source IP not allowed" },
+      { status: 403 }
+    );
+  }
+
+  return null;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,92 +1,139 @@
 /**
- * In-memory rate limiter for Next.js API routes.
+ * Rate limiter for Next.js API routes (#25).
  *
- * Uses a sliding window algorithm with a Map<string, number[]>.
- * This works per-process. For multi-instance deployments, use
- * Redis (e.g. @upstash/ratelimit) instead.
+ * Strategy:
+ *   1. If UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN are set
+ *      AND @upstash/ratelimit is installed → use the distributed
+ *      token-bucket backend that works across Vercel serverless
+ *      invocations.
+ *   2. Else → fall back to the in-memory sliding window. This path
+ *      is only effective on single-process deployments (local dev,
+ *      self-hosted). Vercel serverless per-instance processes will
+ *      **not** share counters — documented limitation.
  *
- * WARNING: Vercel serverless環境ではリクエストごとに別プロセスが起動するため、
- * このMapはプロセス間で共有されない。本番環境では Upstash Redis
- * (@upstash/ratelimit) 等の外部ストアに移行すること。
- * 現状の実装は開発環境・単一プロセス環境でのみ有効。
- *
- * API-08: レート制限実装
+ * The public API (applyRateLimit, rateLimit, getClientIp) is stable
+ * across both backends.
  */
 
 interface RateLimitOptions {
-  /** Maximum requests allowed per window */
   limit: number;
-  /** Window size in milliseconds */
   windowMs: number;
 }
 
 interface RateLimitResult {
   success: boolean;
-  /** Remaining requests in current window */
   remaining: number;
-  /** Epoch ms when the window resets */
   resetAt: number;
 }
 
-// Global store — persists across requests within a single process
-const store = new Map<string, number[]>();
+// ─────────────────────────────────────────────────────────────
+// Backend selection (performed lazily on first call)
+// ─────────────────────────────────────────────────────────────
+let _upstashClient: unknown | null = null;
+let _upstashUnavailable = false;
 
-// メモリリーク対策: 期限切れエントリを定期削除（5分ごと）
-// setIntervalの参照を保持することで GC による早期解放を防ぐ
+async function _getUpstashClient(): Promise<unknown | null> {
+  if (_upstashUnavailable) return null;
+  if (_upstashClient) return _upstashClient;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    _upstashUnavailable = true;
+    return null;
+  }
+
+  try {
+    // Dynamic import so the dependency stays optional. Expect-error on
+    // both lines because these packages are not in package.json — the
+    // operator installs them only when opting into Upstash backend.
+    // @ts-expect-error optional-peer-dep
+    const { Ratelimit } = await import("@upstash/ratelimit");
+    // @ts-expect-error optional-peer-dep
+    const { Redis } = await import("@upstash/redis");
+    const redis = new Redis({ url, token });
+    _upstashClient = { Ratelimit, redis };
+    return _upstashClient;
+  } catch {
+    _upstashUnavailable = true;
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// In-memory fallback (kept from the original implementation)
+// ─────────────────────────────────────────────────────────────
+const store = new Map<string, number[]>();
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 const _cleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, timestamps] of store.entries()) {
-    // windowMsが不明なので保守的に最大ウィンドウ（1時間）を使用
     const maxWindowMs = 60 * 60 * 1000;
     const valid = timestamps.filter((t) => t > now - maxWindowMs);
-    if (valid.length === 0) {
-      store.delete(key);
-    } else {
-      store.set(key, valid);
-    }
+    if (valid.length === 0) store.delete(key);
+    else store.set(key, valid);
   }
 }, CLEANUP_INTERVAL_MS);
-
-// Node.js プロセス終了時にタイマーをクリーンアップ（テスト環境でのリーク防止）
 if (typeof _cleanupTimer === "object" && _cleanupTimer !== null && "unref" in _cleanupTimer) {
   (_cleanupTimer as NodeJS.Timeout).unref();
 }
 
-/**
- * Check and record a request for the given identifier.
- *
- * @param identifier - Unique key, typically IP or user ID
- * @param options    - Limit configuration
- */
-export function rateLimit(
+function _rateLimitInMemory(
   identifier: string,
-  options: RateLimitOptions = { limit: 60, windowMs: 60_000 }
+  options: RateLimitOptions
 ): RateLimitResult {
   const now = Date.now();
   const windowStart = now - options.windowMs;
-
-  // Retrieve and prune expired timestamps
   const timestamps = (store.get(identifier) ?? []).filter((t) => t > windowStart);
-
   const remaining = Math.max(0, options.limit - timestamps.length - 1);
   const resetAt = timestamps[0] ? timestamps[0] + options.windowMs : now + options.windowMs;
 
   if (timestamps.length >= options.limit) {
     return { success: false, remaining: 0, resetAt };
   }
-
   timestamps.push(now);
   store.set(identifier, timestamps);
-
   return { success: true, remaining, resetAt };
 }
 
+async function _rateLimitUpstash(
+  client: unknown,
+  identifier: string,
+  options: RateLimitOptions
+): Promise<RateLimitResult> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { Ratelimit, redis } = client as any;
+  // Rebuild on each call to honour per-call limit/windowMs. Acceptable
+  // because Ratelimit itself is cheap to construct; heavy work is the
+  // Redis round-trip which is identical either way.
+  const limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(options.limit, `${options.windowMs} ms`),
+    analytics: false,
+  });
+  const res = await limiter.limit(identifier);
+  return {
+    success: res.success,
+    remaining: res.remaining,
+    resetAt: res.reset,
+  };
+}
+
 /**
- * Extract a best-effort IP from a Next.js Request object.
- *
- * Header priority: cf-connecting-ip → x-real-ip → x-forwarded-for → "anonymous"
+ * Check and record a request for the given identifier.
+ * Async because Upstash is network-backed.
  */
+export async function rateLimit(
+  identifier: string,
+  options: RateLimitOptions = { limit: 60, windowMs: 60_000 }
+): Promise<RateLimitResult> {
+  const client = await _getUpstashClient();
+  if (client) {
+    return _rateLimitUpstash(client, identifier, options);
+  }
+  return _rateLimitInMemory(identifier, options);
+}
+
 export function getClientIp(request: Request): string {
   const h = request.headers;
   const cfIp = h.get("cf-connecting-ip");
@@ -99,18 +146,18 @@ export function getClientIp(request: Request): string {
 }
 
 /**
- * Convenience: check rate limit and return a 429 Response if exceeded.
+ * Convenience: return a 429 Response if rate limited, else null.
  *
- * Usage in a route handler:
- *   const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
+ * Now async because Upstash backend requires awaiting. Callers must:
+ *   const limited = await applyRateLimit(req, { ... });
  *   if (limited) return limited;
  */
-export function applyRateLimit(
+export async function applyRateLimit(
   request: Request,
   options?: RateLimitOptions
-): Response | null {
+): Promise<Response | null> {
   const ip = getClientIp(request);
-  const result = rateLimit(ip, options);
+  const result = await rateLimit(ip, options);
 
   if (!result.success) {
     return new Response(
@@ -127,6 +174,5 @@ export function applyRateLimit(
       }
     );
   }
-
   return null;
 }


### PR DESCRIPTION
## #25 Rate limiter Vercel serverless 対応
UPSTASH_REDIS_REST_URL + TOKEN 設定時 Upstash Ratelimit に自動切替 (dynamic import、optional peer-dep)。未設定時は in-memory fallback。
applyRateLimit / rateLimit を async 化し 13 呼出元を await に更新。

## #27 Cron endpoint hardening
- constant-time Bearer 比較 (timing attack ガード)
- CRON_ALLOWED_IPS env による optional IP allow-list
- 新 helper lib/cron-auth.ts に集約

Closes #25, #27.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed rate limiting behavior across all API endpoints to properly handle asynchronous operations, ensuring consistent and reliable rate-limit enforcement.

* **Chores**
  * Improved cron job security with optional IP allowlisting capability for restricted access control.
  * Extended rate limiting infrastructure with optional Upstash backend support, featuring automatic fallback to in-memory implementation when Upstash is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->