### PR TITLE
feat: Zod + email i18n/retry + live /status (#33, #36, #37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "quality": "npm run lint && npm run test"
   },
   "dependencies": {
+    "@rolldown/binding-linux-x64-gnu": "^1.0.0-rc.12",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.1",
     "clsx": "^2.1.1",

--- a/src/app/api/org/create/route.ts
+++ b/src/app/api/org/create/route.ts
@@ -1,27 +1,25 @@
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { orgCreateSchema, formatZodError } from "@/lib/schemas";
 
 export const dynamic = "force-dynamic";
-
-interface CreateOrgBody {
-  name: string;
-}
 
 export async function POST(request: Request) {
   const limited = applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
-  let body: Partial<CreateOrgBody>;
+  let raw: unknown;
   try {
-    body = (await request.json()) as Partial<CreateOrgBody>;
+    raw = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { name } = body;
-  if (!name || typeof name !== "string" || name.trim() === "") {
-    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  const parsed = orgCreateSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(formatZodError(parsed.error), { status: 400 });
   }
+  const { name } = parsed.data;
 
   let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
   try {
@@ -42,7 +40,7 @@ export async function POST(request: Request) {
   // 組織を作成
   const { data: org, error: orgError } = await supabase
     .from("organizations")
-    .insert({ name: name.trim(), owner_id: user.id })
+    .insert({ name: name, owner_id: user.id })
     .select("id, name, owner_id, plan, created_at")
     .single();
 

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,0 +1,15 @@
+/**
+ * GET /api/status — live health for external consumers + /status page (#37).
+ * Thin wrapper over lib/health-probes (shared with the /status SSR page).
+ */
+import { NextResponse } from "next/server";
+
+import { probeAll } from "@/lib/health-probes";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  const result = await probeAll();
+  return NextResponse.json(result);
+}

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -2,6 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { CheckCircle2, AlertTriangle, XCircle, Clock, Activity } from "lucide-react";
 
+import { probeAll, type ServiceProbe } from "@/lib/health-probes";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export const metadata: Metadata = {
   title: "System Status",
   description: "Real-time status of FaultRay services — API, simulation engine, dashboard, and integrations.",
@@ -11,7 +16,7 @@ export const metadata: Metadata = {
 /* ============================================================
  * Types
  * ============================================================ */
-type ServiceStatus = "operational" | "degraded" | "outage" | "maintenance";
+type ServiceStatus = "operational" | "degraded" | "outage" | "maintenance" | "unknown";
 
 interface Service {
   name: string;
@@ -29,19 +34,14 @@ interface Incident {
   updates: { time: string; message: string }[];
 }
 
-/* ============================================================
- * Static data — in production this would be fetched from
- * a monitoring service (e.g. Betterstack, Statuspage.io)
- * ============================================================ */
-const SERVICES: Service[] = [
-  { name: "API", status: "operational", latency: "142ms", description: "REST API endpoints" },
-  { name: "Simulation Engine", status: "operational", latency: "2.1s", description: "Chaos simulation processing" },
-  { name: "Dashboard", status: "operational", latency: "89ms", description: "Web application interface" },
-  { name: "Authentication", status: "operational", latency: "201ms", description: "Login & session management" },
-  { name: "Report Generation", status: "operational", latency: "3.4s", description: "PDF/HTML report export" },
-  { name: "Webhook / Slack", status: "operational", latency: "310ms", description: "Outbound notifications" },
-  { name: "Data Ingestion", status: "operational", latency: "98ms", description: "YAML/JSON topology import" },
-];
+function _probeToService(p: ServiceProbe): Service {
+  return {
+    name: p.name,
+    status: p.status as ServiceStatus,
+    latency: p.latency_ms != null ? `${p.latency_ms}ms` : undefined,
+    description: p.note ?? "",
+  };
+}
 
 const RECENT_INCIDENTS: Incident[] = [
   {
@@ -74,6 +74,7 @@ function statusLabel(s: ServiceStatus) {
     degraded: "Degraded",
     outage: "Outage",
     maintenance: "Maintenance",
+    unknown: "Unknown",
   };
   return labels[s];
 }
@@ -93,9 +94,11 @@ function overallStatus(services: Service[]): ServiceStatus {
 }
 
 /* ============================================================
- * Page
+ * Page — Server Component; probes Supabase/Stripe/Resend on render (#37).
  * ============================================================ */
-export default function StatusPage() {
+export default async function StatusPage() {
+  const live = await probeAll();
+  const SERVICES: Service[] = live.services.map(_probeToService);
   const overall = overallStatus(SERVICES);
 
   return (

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -46,7 +46,38 @@ function ctaButton(href: string, label: string): string {
   return `<a href="${href}" style="display:inline-block;padding:12px 28px;background:#FFD700;color:#0a0e1a;font-weight:700;font-size:14px;border-radius:8px;text-decoration:none;margin-top:24px;">${label}</a>`;
 }
 
-export function welcomeEmail(name: string): { subject: string; html: string } {
+// ───────────────────────────────────────────────────────────
+// Locale-aware templates (#36). Callers pass `locale` to switch
+// subject + body between supported languages. Default is "en" so
+// existing callers (no locale) keep working.
+// ───────────────────────────────────────────────────────────
+
+export type EmailLocale = "en" | "ja";
+
+export function welcomeEmail(
+  name: string,
+  locale: EmailLocale = "en"
+): { subject: string; html: string } {
+  if (locale === "ja") {
+    const subject = "FaultRay へようこそ — システムのレジリエンスを推定しましょう";
+    const html = baseLayout(`
+      <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">${name} 様、はじめまして</h1>
+      <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#94a3b8;">
+        7 日間の Business トライアルを開始しました。FaultRay は本番環境に触れず
+        2,000+ の障害シナリオをシミュレートできます。
+      </p>
+      <h2 style="margin:24px 0 12px;font-size:16px;font-weight:600;color:#e2e8f0;">クイックスタート</h2>
+      <ol style="margin:0 0 16px;padding-left:20px;font-size:14px;line-height:1.9;color:#94a3b8;">
+        <li><strong style="color:#e2e8f0;">ダッシュボード</strong>から最初のプロジェクトを作成</li>
+        <li>インフラトポロジー (ノード・依存関係) を登録</li>
+        <li>2,000+ の fault シナリオから選んでシミュレーション実行</li>
+        <li>レジリエンススコアと critical な障害パスを確認</li>
+        <li>監査対応レポート (SOC2 / ISO 27001) を生成</li>
+      </ol>
+      ${ctaButton("https://faultray.com/dashboard", "ダッシュボードへ")}
+    `);
+    return { subject, html };
+  }
   const subject = "Welcome to FaultRay — Let's estimate your system's resilience";
   const html = baseLayout(`
     <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Welcome, ${name}!</h1>
@@ -69,8 +100,26 @@ export function welcomeEmail(name: string): { subject: string; html: string } {
 
 export function trialReminderEmail(
   name: string,
-  daysLeft: number
+  daysLeft: number,
+  locale: EmailLocale = "en"
 ): { subject: string; html: string } {
+  if (locale === "ja") {
+    const subject = `FaultRay トライアル残り ${daysLeft} 日`;
+    const urgencyColor = daysLeft <= 2 ? "#ef4444" : "#FFD700";
+    const html = baseLayout(`
+      <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">${name} 様</h1>
+      <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#94a3b8;">
+        FaultRay Business トライアルの残り期間は
+        <strong style="color:${urgencyColor};">${daysLeft} 日</strong>です。
+        シミュレーション結果とレポートを失わないよう、今のうちにアップグレードをご検討ください。
+      </p>
+      ${ctaButton("https://faultray.com/pricing", "今すぐアップグレード")}
+      <p style="margin:24px 0 0;font-size:13px;color:#64748b;">
+        ご不明な点はこのメールに返信ください。最適なプラン選びをお手伝いします。
+      </p>
+    `);
+    return { subject, html };
+  }
   const subject = `Your FaultRay trial ends in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`;
   const urgencyColor = daysLeft <= 2 ? "#ef4444" : "#FFD700";
   const html = baseLayout(`

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,21 @@
+/**
+ * Transactional email sender with retry + locale-aware templates (#36).
+ *
+ * - Uses Resend (RESEND_API_KEY required).
+ * - Retries on 429 / 5xx with exponential backoff (3 attempts total).
+ * - Accepts optional `locale` so callers select the right template.
+ *
+ * Callers should not retry themselves — retry policy is owned here.
+ */
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
+
+const _RETRY_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const _MAX_ATTEMPTS = 3;
+const _BACKOFF_MS = [250, 750];  // sleep between attempts 1→2 and 2→3
+
+function _sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export async function sendEmail({
   to,
@@ -8,23 +25,55 @@ export async function sendEmail({
   to: string;
   subject: string;
   html: string;
-}): Promise<{ success: boolean; error?: string }> {
+}): Promise<{ success: boolean; error?: string; attempts?: number }> {
   if (!RESEND_API_KEY) {
-    console.warn("RESEND_API_KEY not set — email not sent");
+    console.warn("[email] RESEND_API_KEY not set — email not sent");
     return { success: false, error: "No API key" };
   }
-  const res = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: "FaultRay <noreply@faultray.com>",
-      to,
-      subject,
-      html,
-    }),
-  });
-  return { success: res.ok };
+
+  let lastStatus = 0;
+  let lastText = "";
+
+  for (let attempt = 1; attempt <= _MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${RESEND_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: "FaultRay <noreply@faultray.com>",
+          to,
+          subject,
+          html,
+        }),
+      });
+
+      if (res.ok) {
+        return { success: true, attempts: attempt };
+      }
+
+      lastStatus = res.status;
+      lastText = await res.text().catch(() => "");
+
+      if (!_RETRY_STATUS.has(res.status) || attempt === _MAX_ATTEMPTS) {
+        break;
+      }
+      await _sleep(_BACKOFF_MS[attempt - 1] ?? 750);
+    } catch (err) {
+      lastText = err instanceof Error ? err.message : String(err);
+      if (attempt === _MAX_ATTEMPTS) break;
+      await _sleep(_BACKOFF_MS[attempt - 1] ?? 750);
+    }
+  }
+
+  console.error(
+    `[email] send failed after ${_MAX_ATTEMPTS} attempts — status=${lastStatus} body=${lastText.slice(0, 200)}`
+  );
+  return {
+    success: false,
+    error: `status=${lastStatus}`,
+    attempts: _MAX_ATTEMPTS,
+  };
 }

--- a/src/lib/health-probes.ts
+++ b/src/lib/health-probes.ts
@@ -1,0 +1,120 @@
+/**
+ * Live health probes for Supabase / Stripe / Resend (#37).
+ *
+ * Shared between:
+ *   - GET /api/status (JSON endpoint for external consumers)
+ *   - /status page (SSR rendering)
+ *
+ * Each probe has a 1.5s timeout. Services with missing env are
+ * labelled "unknown" (not a failure).
+ */
+
+export type ServiceStatus = "operational" | "degraded" | "outage" | "unknown";
+
+export interface ServiceProbe {
+  name: string;
+  status: ServiceStatus;
+  latency_ms: number | null;
+  note?: string;
+}
+
+async function _withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`timeout after ${ms}ms`)), ms)
+    ),
+  ]);
+}
+
+export async function probeSupabase(): Promise<ServiceProbe> {
+  const start = Date.now();
+  try {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    if (!url) return { name: "Supabase", status: "unknown", latency_ms: null, note: "not configured" };
+    await _withTimeout(fetch(`${url}/rest/v1/`, { method: "HEAD" }), 1500);
+    return { name: "Supabase", status: "operational", latency_ms: Date.now() - start };
+  } catch (err) {
+    return {
+      name: "Supabase",
+      status: "outage",
+      latency_ms: Date.now() - start,
+      note: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function probeStripe(): Promise<ServiceProbe> {
+  const start = Date.now();
+  try {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key || key === "sk_test_placeholder")
+      return { name: "Stripe", status: "unknown", latency_ms: null, note: "not configured" };
+    const res = await _withTimeout(
+      fetch("https://api.stripe.com/v1/charges?limit=1", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${key}` },
+      }),
+      1500
+    );
+    const latency = Date.now() - start;
+    if (res.ok) return { name: "Stripe", status: "operational", latency_ms: latency };
+    return {
+      name: "Stripe",
+      status: res.status >= 500 ? "outage" : "degraded",
+      latency_ms: latency,
+      note: `HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      name: "Stripe",
+      status: "outage",
+      latency_ms: Date.now() - start,
+      note: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function probeResend(): Promise<ServiceProbe> {
+  const start = Date.now();
+  try {
+    const key = process.env.RESEND_API_KEY;
+    if (!key)
+      return { name: "Email (Resend)", status: "unknown", latency_ms: null, note: "not configured" };
+    const res = await _withTimeout(
+      fetch("https://api.resend.com/domains", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${key}` },
+      }),
+      1500
+    );
+    const latency = Date.now() - start;
+    if (res.ok) return { name: "Email (Resend)", status: "operational", latency_ms: latency };
+    return {
+      name: "Email (Resend)",
+      status: res.status >= 500 ? "outage" : "degraded",
+      latency_ms: latency,
+      note: `HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      name: "Email (Resend)",
+      status: "outage",
+      latency_ms: Date.now() - start,
+      note: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function probeAll(): Promise<{
+  overall: ServiceStatus;
+  services: ServiceProbe[];
+  checked_at: string;
+}> {
+  const services = await Promise.all([probeSupabase(), probeStripe(), probeResend()]);
+  let overall: ServiceStatus = "operational";
+  if (services.some((s) => s.status === "outage")) overall = "outage";
+  else if (services.some((s) => s.status === "degraded")) overall = "degraded";
+  else if (services.every((s) => s.status === "unknown")) overall = "unknown";
+  return { overall, services, checked_at: new Date().toISOString() };
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared Zod schemas for API route validation (#33).
+ *
+ * Each POST/PUT route imports the matching schema from here instead
+ * of hand-rolling type guards. Centralises validation + error shape.
+ *
+ * Usage:
+ *   import { orgCreateSchema, formatZodError } from "@/lib/schemas";
+ *
+ *   const parsed = orgCreateSchema.safeParse(await req.json());
+ *   if (!parsed.success) {
+ *     return NextResponse.json(formatZodError(parsed.error), { status: 400 });
+ *   }
+ *   const { name } = parsed.data;
+ */
+
+import { z } from "zod";
+
+const _trimmedNonEmptyString = (max: number) =>
+  z
+    .string()
+    .transform((s) => s.trim())
+    .pipe(z.string().min(1).max(max));
+
+export const orgCreateSchema = z.object({
+  name: _trimmedNonEmptyString(120),
+});
+export type OrgCreateInput = z.infer<typeof orgCreateSchema>;
+
+export const orgInviteSchema = z.object({
+  org_id: z.string().uuid(),
+  email: z.string().email().max(320),
+  role: z.enum(["admin", "member", "viewer"]).default("member"),
+});
+export type OrgInviteInput = z.infer<typeof orgInviteSchema>;
+
+export const taskCreateSchema = z.object({
+  title: _trimmedNonEmptyString(200),
+  description: z.string().max(5000).optional(),
+  source: z.enum(["api", "ui", "webhook"]).default("api"),
+  source_id: z
+    .string()
+    .regex(/^[a-z0-9][a-z0-9-]*$/i, "source_id must be alphanumeric + hyphen")
+    .max(64)
+    .optional(),
+});
+export type TaskCreateInput = z.infer<typeof taskCreateSchema>;
+
+export function formatZodError(err: z.ZodError): {
+  error: string;
+  details: Array<{ path: string; message: string }>;
+} {
+  return {
+    error: "Validation failed",
+    details: err.issues.map((i) => ({
+      path: i.path.join("."),
+      message: i.message,
+    })),
+  };
+}


### PR DESCRIPTION
## #33 Zod schemas
- zod dep 追加 (^4.2.0)
- lib/schemas.ts: orgCreate / orgInvite / taskCreate + formatZodError
- org/create route が schema.safeParse 経由に

## #36 Email retry + i18n
- sendEmail() に exp-backoff retry (3 attempts, 429/5xx のみ)
- welcomeEmail / trialReminderEmail に locale='ja' 対応 (後方互換)

## #37 Live /status
- lib/health-probes.ts: Supabase / Stripe / Resend probe (1.5s timeout)
- /api/status: JSON endpoint
- /status page を async server component 化して live 描画

Closes #33, #36, #37.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
