### PR TITLE
hotfix: await applyRateLimit in trial-expiry cron route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ __pycache__/
 tests/screenshots/
 tests/e2e_buttons.py
 playwright-report/
+supabase/.temp/

--- a/src/app/api/cron/trial-expiry/route.ts
+++ b/src/app/api/cron/trial-expiry/route.ts
@@ -22,7 +22,7 @@ export const dynamic = "force-dynamic";
  * Protected by CRON_SECRET (Bearer) to prevent unauthorized invocation.
  */
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
   const cronSecret = process.env.CRON_SECRET;


### PR DESCRIPTION
merge 順序 (#54 → #48) で trial-expiry が await-less の古い呼出を保持したまま main に入り、tsc error + 実質 production breakage が発生していた。self-review 中に発見。

修正: src/app/api/cron/trial-expiry/route.ts で applyRateLimit 呼出に await を追加。tsc error 0 を確認。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rate limiting logic to properly evaluate request limits before processing.

* **Chores**
  * Updated project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->