### PR TITLE
hotfix(ci): migration 007 self-contained — add trial_ends_at / subscription_status columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ __pycache__/
 tests/screenshots/
 tests/e2e_buttons.py
 playwright-report/
+supabase/.temp/

--- a/src/app/api/cron/trial-expiry/route.ts
+++ b/src/app/api/cron/trial-expiry/route.ts
@@ -22,7 +22,7 @@ export const dynamic = "force-dynamic";
  * Protected by CRON_SECRET (Bearer) to prevent unauthorized invocation.
  */
 export async function POST(request: Request) {
-  const limited = applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
   const cronSecret = process.env.CRON_SECRET;

--- a/supabase/migrations/007_trial_expiry_function.sql
+++ b/supabase/migrations/007_trial_expiry_function.sql
@@ -21,6 +21,31 @@
 --   それ以外 (null / canceled / incomplete / unpaid) は downgrade 対象
 -- ============================================================
 
+-- CI-SAFE: Legacy columns trial_ends_at / subscription_status were added
+-- post-001 via supabase/add_*.sql (not a numbered migration). Fresh CI
+-- databases run 001-008 in order, so those columns must exist here before
+-- the RPC references them. IF NOT EXISTS is idempotent for production.
+alter table public.profiles
+  add column if not exists trial_ends_at timestamptz;
+
+alter table public.profiles
+  add column if not exists subscription_status text default 'active';
+
+-- The CHECK constraint from add_subscription_status.sql, only applied if
+-- we added the column above (same IF NOT EXISTS semantics via DO block).
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.profiles'::regclass
+      and conname  = 'profiles_subscription_status_check'
+  ) then
+    alter table public.profiles
+      add constraint profiles_subscription_status_check
+      check (subscription_status in ('active', 'past_due', 'canceled', 'trialing'));
+  end if;
+end $$;
+
 create or replace function public.downgrade_expired_trials()
 returns table (id uuid, email text)
 language sql


### PR DESCRIPTION
CI の RLS pgTAP job が failure: fresh DB に 001-008 順次適用時、trial_ends_at / subscription_status columns が 001 になく legacy supabase/add_*.sql (migrations/ 外) 頼みだったため 007 で column does not exist エラー。

修正: 007 冒頭で ALTER TABLE ADD COLUMN IF NOT EXISTS + CHECK constraint を DO block で冪等化。prod/staging への re-apply も OK を確認済み。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
