### PR TITLE
chore(ci): bump actions/{checkout,setup-node,setup-python} to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -43,10 +43,10 @@ jobs:
     name: Frontend Tests (Vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -65,10 +65,10 @@ jobs:
     name: Python Tests (pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -94,7 +94,7 @@ jobs:
       PGPASSWORD: postgres  # pragma: allowlist secret
       PGDATABASE: postgres
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install PostgreSQL 16 + pgTAP on runner
         # pgTAP 拡張は service container の postgres:16 イメージに同梱されていない。
@@ -198,10 +198,10 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
       NEXT_PUBLIC_API_URL: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/setup-python` v5 → v6

## Why
Equivalent to dependabot PRs #57/#58/#59 that were closed because the OAuth token used for CLI merge lacks the GitHub `workflow` scope.

## Verified breaking changes (web-fetched 2026-04-30)
- All v6 actions require Node 24 + runner >= v2.327.1 (GitHub-hosted runners are OK)
- `setup-node` v6 limits auto-cache to npm — repo uses npm + `cache:"npm"`, no migration needed
- `checkout` v6 changes persist-credentials storage — no impact (workflow does not chain credentials between steps)

## Test plan
- [ ] CI passes on this PR
- [ ] No regression in cache hit rate (compare before/after build times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
