### PR TITLE
security: harden RLS + CSRF + Stripe idempotency (Codex audit 2026-04-30)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -138,7 +142,7 @@
         "filename": "src/app/api/account/delete/route.ts",
         "hashed_secret": "6dc93fd5dfc39087aedf8cdc970dcd814aaffed9",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 97
       }
     ],
     "src/app/api/stripe/checkout/route.ts": [
@@ -147,7 +151,7 @@
         "filename": "src/app/api/stripe/checkout/route.ts",
         "hashed_secret": "6dc93fd5dfc39087aedf8cdc970dcd814aaffed9",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 48
       }
     ],
     "src/app/api/stripe/webhook/route.ts": [
@@ -474,5 +478,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T08:58:11Z"
+  "generated_at": "2026-04-30T08:04:41Z"
 }

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -9,6 +9,7 @@
  */
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 import Stripe from "stripe";
 
 export const dynamic = "force-dynamic";
@@ -17,12 +18,18 @@ export async function DELETE(request: Request) {
   const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
+  // Auth + CSRF gate. CSRF protection is critical here: account deletion is
+  // irreversible, so a CSRF-induced DELETE from another origin would be
+  // catastrophic. requireAuth runs checkCsrf() before reading session.
+  const { user, error: authError } = await requireAuth(request);
+  if (authError) return authError;
+
   // Parse optional confirmation body
   let body: { confirm?: boolean } = {};
   try {
     body = (await request.json()) as { confirm?: boolean };
   } catch {
-    // No body is fine; we rely on the auth check below
+    // No body is fine; we already authenticated above
   }
 
   if (!body.confirm) {
@@ -30,19 +37,6 @@ export async function DELETE(request: Request) {
       { error: "Confirmation required. Send { \"confirm\": true } in the request body." },
       { status: 400 }
     );
-  }
-
-  // Authenticate via SSR Supabase client (reads session from cookies)
-  const { createClient } = await import("@/lib/supabase/server");
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
-
-  if (userError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const userId = user.id;

--- a/src/app/api/coupon/redeem/route.ts
+++ b/src/app/api/coupon/redeem/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +12,11 @@ export async function POST(request: Request) {
   // API-08: レート制限 — 5 attempts / minute per IP (brute-force protection)
   const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
+
+  // Auth + CSRF gate (P1-2). Was using bare auth.getUser() so CSRF check was
+  // skipped — a malicious cross-origin POST could redeem a victim's coupon.
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
 
   let body: Partial<RedeemBody>;
   try {
@@ -25,24 +31,7 @@ export async function POST(request: Request) {
   }
   const normalizedCode = code.trim().toUpperCase();
 
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  // 1. 認証チェック
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // 2. couponsテーブルからコードを検索
+  // 1. couponsテーブルからコードを検索 (RLS-protected user client)
   const { data: coupon, error: couponError } = await supabase
     .from("coupons")
     .select("id, code, tier, days, max_uses, current_uses, revoked")
@@ -53,7 +42,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid coupon code" }, { status: 404 });
   }
 
-  // 3. バリデーション
+  // 2. バリデーション
   if (coupon.revoked) {
     return NextResponse.json({ error: "This coupon has been revoked" }, { status: 400 });
   }
@@ -61,7 +50,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "This coupon has reached its usage limit" }, { status: 400 });
   }
 
-  // 4. クーポンのcurrent_usesを楽観的ロックでインクリメント（プロファイル更新の前に）
+  // 3. クーポンのcurrent_usesを楽観的ロックでインクリメント（プロファイル更新の前に）
   // WHERE current_uses = coupon.current_uses で競合を検出。
   // プロファイル更新より先に行うことで、競合時にプランが無料アップグレードされるのを防ぐ。
   const { data: updatedCoupons, error: incrementError } = await supabase
@@ -83,17 +72,32 @@ export async function POST(request: Request) {
     );
   }
 
-  // 5. profilesテーブルを更新（クーポン消費が確定した後）
+  // 4. profilesテーブルを更新（クーポン消費が確定した後）
+  // P1-1: profiles.plan / trial_ends_at は migration 013 で user role の UPDATE
+  // 権限が剥奪されている (billing bypass 防止)。サービスロール経由で更新する。
   const expiresAt = new Date(
     Date.now() + coupon.days * 24 * 60 * 60 * 1000
   ).toISOString();
 
-  const { error: profileError } = await supabase
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error("[coupon/redeem] service role not configured");
+    return NextResponse.json(
+      { error: "Server configuration error. Please contact support." },
+      { status: 503 }
+    );
+  }
+  const { createClient: createAdminClient } = await import("@supabase/supabase-js");
+  const admin = createAdminClient(supabaseUrl, serviceRoleKey);
+
+  const { error: profileError } = await admin
     .from("profiles")
     .update({ plan: coupon.tier, trial_ends_at: expiresAt })
     .eq("id", user.id);
 
   if (profileError) {
+    console.error("[coupon/redeem] profile update failed:", profileError.message);
     return NextResponse.json({ error: "Failed to update profile" }, { status: 500 });
   }
 

--- a/src/app/api/coupon/redeem/route.ts
+++ b/src/app/api/coupon/redeem/route.ts
@@ -104,20 +104,30 @@ export async function POST(request: Request) {
     // P1-B 補強: profile update が失敗したら current_uses を decrement で
     // best-effort rollback。完璧ではない (race / DB error の二段失敗もある)
     // が、follow-up issue で 1-RPC transaction 化するまでの暫定。
+    // (review-loop 2 P1): rollback の affected row 数も見る。0 行なら別 worker
+    // がこの間に increment しているため burn-without-credit 確定。
     console.error("[coupon/redeem] profile update failed:", profileError.message);
-    const { error: rollbackError } = await supabase
+    const { data: rolledBack, error: rollbackError } = await supabase
       .from("coupons")
       .update({ current_uses: coupon.current_uses })
       .eq("id", coupon.id)
-      .eq("current_uses", coupon.current_uses + 1);
+      .eq("current_uses", coupon.current_uses + 1)
+      .select("id");
     if (rollbackError) {
       console.error(
-        "[coupon/redeem] BURN-WITHOUT-CREDIT: rollback also failed for coupon",
+        "[coupon/redeem] BURN-WITHOUT-CREDIT: rollback DB error for coupon",
         coupon.id,
         "user",
         user.id,
         "error:",
         rollbackError.message
+      );
+    } else if (!rolledBack || rolledBack.length === 0) {
+      console.error(
+        "[coupon/redeem] BURN-WITHOUT-CREDIT: rollback no-op (concurrent redeem moved counter past N+1) for coupon",
+        coupon.id,
+        "user",
+        user.id
       );
     }
     return NextResponse.json({ error: "Failed to update profile" }, { status: 500 });

--- a/src/app/api/coupon/redeem/route.ts
+++ b/src/app/api/coupon/redeem/route.ts
@@ -50,9 +50,24 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "This coupon has reached its usage limit" }, { status: 400 });
   }
 
-  // 3. クーポンのcurrent_usesを楽観的ロックでインクリメント（プロファイル更新の前に）
+  // 3. (review-loop 1, P1-B) Admin client config を increment より前に検証。
+  // Codex review (PR #89) の指摘: 検証を後に置くと service_role 不備時に
+  // current_uses だけ消費されて plan 更新が失敗する "burn-without-credit"
+  // が起きる。検証順序を入れ替え、設定不備は increment 前に弾く。
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error("[coupon/redeem] service role not configured");
+    return NextResponse.json(
+      { error: "Server configuration error. Please contact support." },
+      { status: 503 }
+    );
+  }
+  const { createClient: createAdminClient } = await import("@supabase/supabase-js");
+  const admin = createAdminClient(supabaseUrl, serviceRoleKey);
+
+  // 4. クーポンのcurrent_usesを楽観的ロックでインクリメント。
   // WHERE current_uses = coupon.current_uses で競合を検出。
-  // プロファイル更新より先に行うことで、競合時にプランが無料アップグレードされるのを防ぐ。
   const { data: updatedCoupons, error: incrementError } = await supabase
     .from("coupons")
     .update({ current_uses: coupon.current_uses + 1 })
@@ -72,24 +87,13 @@ export async function POST(request: Request) {
     );
   }
 
-  // 4. profilesテーブルを更新（クーポン消費が確定した後）
+  // 5. profilesテーブルを更新（クーポン消費が確定した後、admin 経由）。
+  // 失敗した場合は increment を rollback。
   // P1-1: profiles.plan / trial_ends_at は migration 013 で user role の UPDATE
-  // 権限が剥奪されている (billing bypass 防止)。サービスロール経由で更新する。
+  // 権限が剥奪されている (billing bypass 防止)。
   const expiresAt = new Date(
     Date.now() + coupon.days * 24 * 60 * 60 * 1000
   ).toISOString();
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!supabaseUrl || !serviceRoleKey) {
-    console.error("[coupon/redeem] service role not configured");
-    return NextResponse.json(
-      { error: "Server configuration error. Please contact support." },
-      { status: 503 }
-    );
-  }
-  const { createClient: createAdminClient } = await import("@supabase/supabase-js");
-  const admin = createAdminClient(supabaseUrl, serviceRoleKey);
 
   const { error: profileError } = await admin
     .from("profiles")
@@ -97,7 +101,25 @@ export async function POST(request: Request) {
     .eq("id", user.id);
 
   if (profileError) {
+    // P1-B 補強: profile update が失敗したら current_uses を decrement で
+    // best-effort rollback。完璧ではない (race / DB error の二段失敗もある)
+    // が、follow-up issue で 1-RPC transaction 化するまでの暫定。
     console.error("[coupon/redeem] profile update failed:", profileError.message);
+    const { error: rollbackError } = await supabase
+      .from("coupons")
+      .update({ current_uses: coupon.current_uses })
+      .eq("id", coupon.id)
+      .eq("current_uses", coupon.current_uses + 1);
+    if (rollbackError) {
+      console.error(
+        "[coupon/redeem] BURN-WITHOUT-CREDIT: rollback also failed for coupon",
+        coupon.id,
+        "user",
+        user.id,
+        "error:",
+        rollbackError.message
+      );
+    }
     return NextResponse.json({ error: "Failed to update profile" }, { status: 500 });
   }
 

--- a/src/app/api/org/create/route.ts
+++ b/src/app/api/org/create/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 import { orgCreateSchema, formatZodError } from "@/lib/schemas";
 
 export const dynamic = "force-dynamic";
@@ -7,6 +8,10 @@ export const dynamic = "force-dynamic";
 export async function POST(request: Request) {
   const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
+
+  // Auth + CSRF gate (P1-2). Cross-origin org-creation requests are rejected.
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
 
   let raw: unknown;
   try {
@@ -20,22 +25,6 @@ export async function POST(request: Request) {
     return NextResponse.json(formatZodError(parsed.error), { status: 400 });
   }
   const { name } = parsed.data;
-
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
 
   // 組織を作成
   const { data: org, error: orgError } = await supabase

--- a/src/app/api/org/invite/route.ts
+++ b/src/app/api/org/invite/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -9,11 +10,17 @@ interface InviteBody {
   role: string;
 }
 
+// P1-7: 'owner' は招待経由で付与不可。owner promotion は service_role RPC のみ。
+// migration 013 の "Admins can invite" policy で role IN ('member','admin') を強制。
 const VALID_ROLES = ["admin", "member", "viewer"] as const;
 
 export async function POST(request: Request) {
   const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
+
+  // Auth + CSRF gate (P1-2).
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
 
   let body: Partial<InviteBody>;
   try {
@@ -35,22 +42,6 @@ export async function POST(request: Request) {
       { error: `role must be one of: ${VALID_ROLES.join(", ")}` },
       { status: 400 }
     );
-  }
-
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   // 自分がowner/adminかチェック

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -38,6 +39,11 @@ export async function POST(request: Request) {
   const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
+  // Auth + CSRF gate (P1-2). Was using bare auth.getUser() without CSRF check.
+  const { user, error: authError } = await requireAuth(request);
+  if (authError) return authError;
+  const userId = user.id;
+
   const secretKey = process.env.STRIPE_SECRET_KEY;
   if (!secretKey || secretKey === "sk_test_placeholder") {
     return NextResponse.json(
@@ -69,24 +75,31 @@ export async function POST(request: Request) {
     );
   }
 
-  // API-01: 認証必須 — ログインユーザーのみチェックアウト可能
-  const { createClient } = await import("@/lib/supabase/server");
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  const userId = user.id;
-
   // APIPERF-05: Stripe API呼び出しにタイムアウトを設定（デフォルト80sを30sに短縮）
   const stripe = new Stripe(secretKey, { timeout: 30000 });
 
-  const origin =
-    request.headers.get("origin") ??
-    process.env.NEXT_PUBLIC_SITE_URL ??
-    "https://faultray.com";
+  // P2-1: success_url / cancel_url は server-side allowlist のみ。以前は
+  // request.headers.get('origin') を最優先していたため、cross-origin な
+  // 認証済みリクエストで attacker domain への post-payment redirect が成立
+  // しうる Stripe Checkout Session を作れた。
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!siteUrl) {
+    console.error("[stripe/checkout] NEXT_PUBLIC_SITE_URL not configured");
+    return NextResponse.json(
+      { error: "Server configuration error. Please contact support." },
+      { status: 503 }
+    );
+  }
+  let origin: string;
+  try {
+    origin = new URL(siteUrl).origin;
+  } catch {
+    console.error("[stripe/checkout] NEXT_PUBLIC_SITE_URL is not a valid URL:", siteUrl);
+    return NextResponse.json(
+      { error: "Server configuration error. Please contact support." },
+      { status: 503 }
+    );
+  }
 
   const unitAmount = PRICES[plan][interval];
   const trialDays = TRIAL_DAYS[plan];

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -78,23 +78,40 @@ export async function POST(request: Request) {
   // APIPERF-05: Stripe API呼び出しにタイムアウトを設定（デフォルト80sを30sに短縮）
   const stripe = new Stripe(secretKey, { timeout: 30000 });
 
-  // P2-1: success_url / cancel_url は server-side allowlist のみ。以前は
-  // request.headers.get('origin') を最優先していたため、cross-origin な
-  // 認証済みリクエストで attacker domain への post-payment redirect が成立
-  // しうる Stripe Checkout Session を作れた。
+  // P2-1 (review-loop 1): success_url / cancel_url は server-side allowlist のみ。
+  // Codex review (PR #89) の指摘: 本番のみ NEXT_PUBLIC_SITE_URL 必須にし、
+  // preview/dev では VERCEL_URL fallback (これも server-only env、改竄不可)
+  // を許容して checkout 不能を回避する。
+  // Origin: ANY case で request.headers.get('origin') は使わない (P2-1 の核心)。
+  const isProduction = process.env.NODE_ENV === "production";
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
-  if (!siteUrl) {
-    console.error("[stripe/checkout] NEXT_PUBLIC_SITE_URL not configured");
+  const vercelUrl = process.env.VERCEL_URL;
+
+  let origin: string | null = null;
+  for (const candidate of [siteUrl, vercelUrl ? `https://${vercelUrl}` : null]) {
+    if (!candidate) continue;
+    try {
+      origin = new URL(candidate).origin;
+      break;
+    } catch {
+      // try next candidate
+    }
+  }
+  if (isProduction && !siteUrl) {
+    // In production we require explicit NEXT_PUBLIC_SITE_URL; refuse silent
+    // VERCEL_URL fallback to avoid mis-pinning to a preview deployment.
+    console.error(
+      "[stripe/checkout] NEXT_PUBLIC_SITE_URL must be set in production"
+    );
     return NextResponse.json(
       { error: "Server configuration error. Please contact support." },
       { status: 503 }
     );
   }
-  let origin: string;
-  try {
-    origin = new URL(siteUrl).origin;
-  } catch {
-    console.error("[stripe/checkout] NEXT_PUBLIC_SITE_URL is not a valid URL:", siteUrl);
+  if (!origin) {
+    console.error(
+      "[stripe/checkout] no valid origin (NEXT_PUBLIC_SITE_URL/VERCEL_URL both missing or malformed)"
+    );
     return NextResponse.json(
       { error: "Server configuration error. Please contact support." },
       { status: 503 }

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -78,44 +78,57 @@ export async function POST(request: Request) {
   // APIPERF-05: Stripe API呼び出しにタイムアウトを設定（デフォルト80sを30sに短縮）
   const stripe = new Stripe(secretKey, { timeout: 30000 });
 
-  // P2-1 (review-loop 1): success_url / cancel_url は server-side allowlist のみ。
-  // Codex review (PR #89) の指摘: 本番のみ NEXT_PUBLIC_SITE_URL 必須にし、
-  // preview/dev では VERCEL_URL fallback (これも server-only env、改竄不可)
-  // を許容して checkout 不能を回避する。
+  // P2-1 (review-loop 2): success_url / cancel_url は server-side allowlist のみ。
+  // 本番では NEXT_PUBLIC_SITE_URL が**設定 AND parse 可能**であることを要求。
+  // malformed の場合に VERCEL_URL fallback すると preview deployment URL に
+  // pin されてしまうため、production は厳格に弾く。
+  // 非本番のみ VERCEL_URL fallback (server-only env、改竄不可) を許容。
   // Origin: ANY case で request.headers.get('origin') は使わない (P2-1 の核心)。
   const isProduction = process.env.NODE_ENV === "production";
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
   const vercelUrl = process.env.VERCEL_URL;
 
-  let origin: string | null = null;
-  for (const candidate of [siteUrl, vercelUrl ? `https://${vercelUrl}` : null]) {
-    if (!candidate) continue;
+  function tryOrigin(value: string | null | undefined): string | null {
+    if (!value) return null;
     try {
-      origin = new URL(candidate).origin;
-      break;
+      return new URL(value).origin;
     } catch {
-      // try next candidate
+      return null;
     }
   }
-  if (isProduction && !siteUrl) {
-    // In production we require explicit NEXT_PUBLIC_SITE_URL; refuse silent
-    // VERCEL_URL fallback to avoid mis-pinning to a preview deployment.
-    console.error(
-      "[stripe/checkout] NEXT_PUBLIC_SITE_URL must be set in production"
-    );
-    return NextResponse.json(
-      { error: "Server configuration error. Please contact support." },
-      { status: 503 }
-    );
-  }
-  if (!origin) {
-    console.error(
-      "[stripe/checkout] no valid origin (NEXT_PUBLIC_SITE_URL/VERCEL_URL both missing or malformed)"
-    );
-    return NextResponse.json(
-      { error: "Server configuration error. Please contact support." },
-      { status: 503 }
-    );
+
+  let origin: string | null = null;
+  if (isProduction) {
+    // Production: require valid NEXT_PUBLIC_SITE_URL, no fallback.
+    if (!siteUrl) {
+      console.error("[stripe/checkout] NEXT_PUBLIC_SITE_URL must be set in production");
+      return NextResponse.json(
+        { error: "Server configuration error. Please contact support." },
+        { status: 503 }
+      );
+    }
+    origin = tryOrigin(siteUrl);
+    if (!origin) {
+      console.error("[stripe/checkout] NEXT_PUBLIC_SITE_URL is malformed in production:", siteUrl);
+      return NextResponse.json(
+        { error: "Server configuration error. Please contact support." },
+        { status: 503 }
+      );
+    }
+  } else {
+    // Non-production: NEXT_PUBLIC_SITE_URL → VERCEL_URL fallback chain.
+    origin =
+      tryOrigin(siteUrl) ??
+      tryOrigin(vercelUrl ? `https://${vercelUrl}` : null);
+    if (!origin) {
+      console.error(
+        "[stripe/checkout] no valid origin in non-prod (NEXT_PUBLIC_SITE_URL/VERCEL_URL both missing or malformed)"
+      );
+      return NextResponse.json(
+        { error: "Server configuration error. Please contact support." },
+        { status: 503 }
+      );
+    }
   }
 
   const unitAmount = PRICES[plan][interval];

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -78,13 +78,24 @@ export async function POST(request: Request) {
   // APIPERF-05: Stripe API呼び出しにタイムアウトを設定（デフォルト80sを30sに短縮）
   const stripe = new Stripe(secretKey, { timeout: 30000 });
 
-  // P2-1 (review-loop 2): success_url / cancel_url は server-side allowlist のみ。
+  // P2-1 (review-loop 2 + 3): success_url / cancel_url は server-side allowlist のみ。
   // 本番では NEXT_PUBLIC_SITE_URL が**設定 AND parse 可能**であることを要求。
   // malformed の場合に VERCEL_URL fallback すると preview deployment URL に
   // pin されてしまうため、production は厳格に弾く。
   // 非本番のみ VERCEL_URL fallback (server-only env、改竄不可) を許容。
   // Origin: ANY case で request.headers.get('origin') は使わない (P2-1 の核心)。
-  const isProduction = process.env.NODE_ENV === "production";
+  //
+  // NODE_ENV ではなく VERCEL_ENV で本番判定する (Codex P2): preview / staging
+  // deployment は Next.js build 時に NODE_ENV='production' になるため、
+  // NODE_ENV だけで isProduction 判定すると preview でも production 厳格パスを
+  // 通り、NEXT_PUBLIC_SITE_URL 未設定の preview/staging で 503 になる。
+  // VERCEL_ENV は production / preview / development のいずれかで明示的に区別可能。
+  // VERCEL_ENV 未設定 (Vercel 外で動かしている self-host 等) では、過去互換のため
+  // NODE_ENV='production' を本番扱いする。
+  const vercelEnv = process.env.VERCEL_ENV;
+  const isProduction = vercelEnv
+    ? vercelEnv === "production"
+    : process.env.NODE_ENV === "production";
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
   const vercelUrl = process.env.VERCEL_URL;
 

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -130,6 +130,54 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Webhook signature verification failed" }, { status: 400 });
   }
 
+  // P1-4: Idempotency guard (Codex audit 2026-04-30).
+  // Insert event.id with UNIQUE constraint BEFORE side effects so duplicate
+  // deliveries (Stripe retries / replay within signature timestamp window)
+  // are short-circuited atomically.
+  // Schema: supabase/migrations/013_security_hardening.sql.processed_stripe_events
+  try {
+    const dedupeAdmin = await getSupabaseAdmin();
+    const eventCustomerId =
+      typeof (event.data.object as { customer?: unknown })?.customer === "string"
+        ? ((event.data.object as { customer?: string }).customer ?? null)
+        : null;
+    const { error: insertError } = await dedupeAdmin
+      .from("processed_stripe_events")
+      .insert({
+        event_id: event.id,
+        event_type: event.type,
+        customer_id: eventCustomerId,
+      });
+    if (insertError) {
+      // Postgres unique_violation = '23505'. Supabase JS surfaces that as
+      // PostgrestError with code '23505'.
+      const code = (insertError as { code?: string }).code;
+      if (code === "23505") {
+        console.info(
+          `[stripe/webhook] duplicate event ${event.id} (${event.type}) — skipping`
+        );
+        return NextResponse.json({ received: true, duplicate: true });
+      }
+      // Non-conflict insert error → fail to make Stripe retry rather than
+      // silently swallow.
+      console.error(
+        "[stripe/webhook] processed_stripe_events insert failed:",
+        insertError.message
+      );
+      return NextResponse.json(
+        { error: "Idempotency ledger write failed" },
+        { status: 500 }
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[stripe/webhook] Idempotency guard error:", message);
+    return NextResponse.json(
+      { error: "Idempotency guard failure" },
+      { status: 500 }
+    );
+  }
+
   try {
     switch (event.type) {
       // ── Checkout completed: new subscription starts ──────────────────────

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -139,11 +139,14 @@ export async function POST(request: Request) {
   // 動作:
   //   1) INSERT (event_id, status='processing') ON CONFLICT DO NOTHING
   //   2) INSERT 成功 (= 初到達) → 通常処理 → 成功時 UPDATE status='processed'
-  //      side effect 失敗時は DELETE して Stripe に retry させる (500 return)
+  //      side effect 失敗時は UPDATE status='failed' して Stripe の retry で
+  //      reclaim させる (500 return)
   //   3) INSERT 衝突 (= 重複) → 既存 status check:
-  //        processed → 200 duplicate (即返却)
-  //        processing → 202 accepted (別 worker 処理中、Stripe は retry する)
-  //        failed → 再処理 (UPDATE status='processing' に戻して続行)
+  //        processed  → 200 duplicate (即返却)
+  //        processing → 503 (Stripe retry 駆動)。worker crash で永久 'processing'
+  //                     残留時に 2xx を返すと Stripe が retry を停止し billing が
+  //                     永久未適用になる (Codex P1, Devin BUG)。
+  //        failed     → 再処理 (UPDATE status='processing' に戻して続行)
   let dedupeAdmin: Awaited<ReturnType<typeof getSupabaseAdmin>>;
   try {
     dedupeAdmin = await getSupabaseAdmin();
@@ -210,10 +213,14 @@ export async function POST(request: Request) {
         return NextResponse.json({ received: true, duplicate: true });
       }
       if (existing.status === "processing") {
-        // Another worker is processing — let Stripe retry later.
+        // Another worker is processing — return non-2xx so Stripe retries.
+        // Stripe treats any 2xx as successful delivery and stops automatic
+        // retries. If the original worker crashed/timed out before flipping
+        // status, the row stays 'processing' forever and side effects never
+        // apply unless we keep Stripe retrying. (Codex P1 / Devin BUG)
         return NextResponse.json(
-          { received: true, status: "in_progress" },
-          { status: 202 }
+          { received: false, status: "in_progress" },
+          { status: 503 }
         );
       }
       // status === 'failed' → re-claim by flipping back to 'processing'.
@@ -237,10 +244,13 @@ export async function POST(request: Request) {
         );
       }
       if (!reclaimed || reclaimed.length === 0) {
-        // Another worker reclaimed in the meantime — treat as in-progress.
+        // Another worker reclaimed in the meantime — return non-2xx so Stripe
+        // retries (same reasoning as the 'processing' branch above). The
+        // other worker may also crash before flipping status, so we cannot
+        // assume the event will be processed without further retries.
         return NextResponse.json(
-          { received: true, status: "in_progress" },
-          { status: 202 }
+          { received: false, status: "in_progress" },
+          { status: 503 }
         );
       }
       claimedNew = true;

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -130,53 +130,112 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Webhook signature verification failed" }, { status: 400 });
   }
 
-  // P1-4: Idempotency guard (Codex audit 2026-04-30).
-  // Insert event.id with UNIQUE constraint BEFORE side effects so duplicate
-  // deliveries (Stripe retries / replay within signature timestamp window)
-  // are short-circuited atomically.
-  // Schema: supabase/migrations/013_security_hardening.sql.processed_stripe_events
+  // P1-4 (PR #89 → review-loop 1): 2-state idempotency ledger.
+  // Codex review (2026-04-30) の P1 指摘:
+  //   "INSERT-before-side-effect では updateUserPlan() throw 時に event が
+  //    永久 dedup → DB inconsistent。claim/processed の 2-state ledger に
+  //    すべき"
+  //
+  // 動作:
+  //   1) INSERT (event_id, status='processing') ON CONFLICT DO NOTHING
+  //   2) INSERT 成功 (= 初到達) → 通常処理 → 成功時 UPDATE status='processed'
+  //      side effect 失敗時は DELETE して Stripe に retry させる (500 return)
+  //   3) INSERT 衝突 (= 重複) → 既存 status check:
+  //        processed → 200 duplicate (即返却)
+  //        processing → 202 accepted (別 worker 処理中、Stripe は retry する)
+  //        failed → 再処理 (UPDATE status='processing' に戻して続行)
+  let dedupeAdmin: Awaited<ReturnType<typeof getSupabaseAdmin>>;
   try {
-    const dedupeAdmin = await getSupabaseAdmin();
-    const eventCustomerId =
-      typeof (event.data.object as { customer?: unknown })?.customer === "string"
-        ? ((event.data.object as { customer?: string }).customer ?? null)
-        : null;
+    dedupeAdmin = await getSupabaseAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[stripe/webhook] Admin client init failed:", message);
+    return NextResponse.json(
+      { error: "Idempotency guard failure" },
+      { status: 500 }
+    );
+  }
+
+  const eventCustomerId =
+    typeof (event.data.object as { customer?: unknown })?.customer === "string"
+      ? ((event.data.object as { customer?: string }).customer ?? null)
+      : null;
+
+  let claimedNew = false;
+  {
     const { error: insertError } = await dedupeAdmin
       .from("processed_stripe_events")
       .insert({
         event_id: event.id,
         event_type: event.type,
         customer_id: eventCustomerId,
+        status: "processing",
       });
-    if (insertError) {
-      // Postgres unique_violation = '23505'. Supabase JS surfaces that as
-      // PostgrestError with code '23505'.
+
+    if (!insertError) {
+      claimedNew = true;
+    } else {
+      // 23505 = postgres unique_violation
       const code = (insertError as { code?: string }).code;
-      if (code === "23505") {
-        console.info(
-          `[stripe/webhook] duplicate event ${event.id} (${event.type}) — skipping`
+      if (code !== "23505") {
+        console.error(
+          "[stripe/webhook] processed_stripe_events insert failed:",
+          insertError.message
         );
+        return NextResponse.json(
+          { error: "Idempotency ledger write failed" },
+          { status: 500 }
+        );
+      }
+
+      // Conflict path: inspect existing row and decide.
+      const { data: existing, error: selectError } = await dedupeAdmin
+        .from("processed_stripe_events")
+        .select("status")
+        .eq("event_id", event.id)
+        .maybeSingle();
+
+      if (selectError || !existing) {
+        console.error(
+          "[stripe/webhook] failed to read existing event row:",
+          selectError?.message
+        );
+        return NextResponse.json(
+          { error: "Idempotency ledger read failed" },
+          { status: 500 }
+        );
+      }
+
+      if (existing.status === "processed") {
         return NextResponse.json({ received: true, duplicate: true });
       }
-      // Non-conflict insert error → fail to make Stripe retry rather than
-      // silently swallow.
-      console.error(
-        "[stripe/webhook] processed_stripe_events insert failed:",
-        insertError.message
-      );
-      return NextResponse.json(
-        { error: "Idempotency ledger write failed" },
-        { status: 500 }
-      );
+      if (existing.status === "processing") {
+        // Another worker is processing — let Stripe retry later.
+        return NextResponse.json(
+          { received: true, status: "in_progress" },
+          { status: 202 }
+        );
+      }
+      // status === 'failed' → re-claim by flipping back to 'processing'.
+      const { error: reclaimError } = await dedupeAdmin
+        .from("processed_stripe_events")
+        .update({ status: "processing", last_error: null })
+        .eq("event_id", event.id)
+        .eq("status", "failed");
+      if (reclaimError) {
+        console.error(
+          "[stripe/webhook] failed to re-claim failed event:",
+          reclaimError.message
+        );
+        return NextResponse.json(
+          { error: "Idempotency ledger reclaim failed" },
+          { status: 500 }
+        );
+      }
+      claimedNew = true;
     }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("[stripe/webhook] Idempotency guard error:", message);
-    return NextResponse.json(
-      { error: "Idempotency guard failure" },
-      { status: 500 }
-    );
   }
+  // claimedNew === true: we own this event; must mark processed/failed before return.
 
   try {
     switch (event.type) {
@@ -303,7 +362,36 @@ export async function POST(request: Request) {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error(`[stripe/webhook] Error handling event ${event.type}:`, message);
+    // 2-state ledger: mark as 'failed' so Stripe's next retry can reclaim
+    // and re-run side effects. (013 + 014)
+    const { error: markFailedError } = await dedupeAdmin
+      .from("processed_stripe_events")
+      .update({ status: "failed", last_error: message })
+      .eq("event_id", event.id);
+    if (markFailedError) {
+      console.error(
+        "[stripe/webhook] failed to mark event failed:",
+        markFailedError.message
+      );
+    }
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+
+  // Success path: flip claim from 'processing' to 'processed'.
+  // Must happen AFTER all side effects committed.
+  if (claimedNew) {
+    const { error: markError } = await dedupeAdmin
+      .from("processed_stripe_events")
+      .update({ status: "processed" })
+      .eq("event_id", event.id);
+    if (markError) {
+      // Side effects already committed; we cannot 500 here (would force
+      // Stripe to retry and double-apply). Log and continue.
+      console.error(
+        "[stripe/webhook] failed to mark event processed:",
+        markError.message
+      );
+    }
   }
 
   return NextResponse.json({ received: true });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -258,38 +258,57 @@ export async function POST(request: Request) {
             { status: 503 }
           );
         }
-      }
-      // status === 'failed' → re-claim by flipping back to 'processing'.
-      // (review-loop 2, P1) .select() で affected row 数を確認し、
-      // 同時 retry が 2件 'failed' を見て両方 reclaim を試みた race を防ぐ。
-      // 1件だけが update できる (もう1件は 0 rows = 別 worker が先に reclaim 済)。
-      const { data: reclaimed, error: reclaimError } = await dedupeAdmin
-        .from("processed_stripe_events")
-        .update({ status: "processing", last_error: null })
-        .eq("event_id", event.id)
-        .eq("status", "failed")
-        .select("event_id");
-      if (reclaimError) {
+      } else if (existing.status === "failed") {
+        // status === 'failed' → re-claim by flipping back to 'processing'.
+        // (review-loop 2, P1) .select() で affected row 数を確認し、
+        // 同時 retry が 2件 'failed' を見て両方 reclaim を試みた race を防ぐ。
+        // 1件だけが update できる (もう1件は 0 rows = 別 worker が先に reclaim 済)。
+        //
+        // (review-loop 5, CodeRabbit Major + Codex P1) この block を else if で
+        // 囲むのが必須。'processing' branch の stale takeover が成功した場合に
+        // ここに fall through すると、`.eq("status", "failed")` が 0 rows match
+        // (実際は既に 'processing' になっている) → 503 return → 取得した claim を
+        // 投げ捨てて side effect が永久未実行になる、という重大バグを防ぐ。
+        const { data: reclaimed, error: reclaimError } = await dedupeAdmin
+          .from("processed_stripe_events")
+          .update({ status: "processing", last_error: null })
+          .eq("event_id", event.id)
+          .eq("status", "failed")
+          .select("event_id");
+        if (reclaimError) {
+          console.error(
+            "[stripe/webhook] failed to re-claim failed event:",
+            reclaimError.message
+          );
+          return NextResponse.json(
+            { error: "Idempotency ledger reclaim failed" },
+            { status: 500 }
+          );
+        }
+        if (!reclaimed || reclaimed.length === 0) {
+          // Another worker reclaimed in the meantime — return non-2xx so Stripe
+          // retries (same reasoning as the 'processing' branch above). The
+          // other worker may also crash before flipping status, so we cannot
+          // assume the event will be processed without further retries.
+          return NextResponse.json(
+            { received: false, status: "in_progress" },
+            { status: 503 }
+          );
+        }
+        claimedNew = true;
+      } else {
+        // Defensive: unknown status value should not happen given the CHECK
+        // constraint on processed_stripe_events.status, but if a future
+        // migration adds a new state we want explicit failure rather than
+        // silent skip.
         console.error(
-          "[stripe/webhook] failed to re-claim failed event:",
-          reclaimError.message
+          `[stripe/webhook] unexpected processed_stripe_events.status=${existing.status} for event ${event.id}`
         );
         return NextResponse.json(
-          { error: "Idempotency ledger reclaim failed" },
+          { error: "Idempotency ledger unknown state" },
           { status: 500 }
         );
       }
-      if (!reclaimed || reclaimed.length === 0) {
-        // Another worker reclaimed in the meantime — return non-2xx so Stripe
-        // retries (same reasoning as the 'processing' branch above). The
-        // other worker may also crash before flipping status, so we cannot
-        // assume the event will be processed without further retries.
-        return NextResponse.json(
-          { received: false, status: "in_progress" },
-          { status: 503 }
-        );
-      }
-      claimedNew = true;
     }
   }
   // claimedNew === true: we own this event; must mark processed/failed before return.

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -194,7 +194,7 @@ export async function POST(request: Request) {
       // Conflict path: inspect existing row and decide.
       const { data: existing, error: selectError } = await dedupeAdmin
         .from("processed_stripe_events")
-        .select("status")
+        .select("status, updated_at")
         .eq("event_id", event.id)
         .maybeSingle();
 
@@ -213,15 +213,51 @@ export async function POST(request: Request) {
         return NextResponse.json({ received: true, duplicate: true });
       }
       if (existing.status === "processing") {
-        // Another worker is processing — return non-2xx so Stripe retries.
-        // Stripe treats any 2xx as successful delivery and stops automatic
-        // retries. If the original worker crashed/timed out before flipping
-        // status, the row stays 'processing' forever and side effects never
-        // apply unless we keep Stripe retrying. (Codex P1 / Devin BUG)
-        return NextResponse.json(
-          { received: false, status: "in_progress" },
-          { status: 503 }
-        );
+        // Stale-lock takeover (review-loop 3, CodeRabbit Major + Codex P1):
+        // worker crash / serverless timeout で 'processing' 残留時、503 だけ
+        // 返していると Stripe retry が無限に空回りして event は永久 stuck。
+        // updated_at が STALE_PROCESSING_MS 以上経過していれば前 worker は
+        // 死んだとみなし、現 worker が reclaim する (status='processing' のまま
+        // updated_at だけ bump して所有権を奪う)。
+        // 同条件 + .eq("status", "processing") + .lt("updated_at", cutoff) で
+        // race 安全 (2 workers が同時に試みても 1 件しか update できない)。
+        const STALE_PROCESSING_MS = 5 * 60_000; // 5 minutes
+        const staleCutoff = new Date(
+          Date.now() - STALE_PROCESSING_MS
+        ).toISOString();
+        const { data: reclaimedStale, error: reclaimStaleError } =
+          await dedupeAdmin
+            .from("processed_stripe_events")
+            .update({ status: "processing", last_error: null })
+            .eq("event_id", event.id)
+            .eq("status", "processing")
+            .lt("updated_at", staleCutoff)
+            .select("event_id");
+        if (reclaimStaleError) {
+          console.error(
+            "[stripe/webhook] stale 'processing' reclaim failed:",
+            reclaimStaleError.message
+          );
+          return NextResponse.json(
+            { error: "Idempotency ledger stale-reclaim failed" },
+            { status: 500 }
+          );
+        }
+        if (reclaimedStale && reclaimedStale.length > 0) {
+          console.warn(
+            `[stripe/webhook] reclaimed stale 'processing' event ${event.id} ` +
+              `(>${STALE_PROCESSING_MS / 60_000}min old)`
+          );
+          claimedNew = true;
+        } else {
+          // Active worker is still within the freshness window — let Stripe
+          // retry. 503 keeps Stripe retrying (2xx would stop retries; see
+          // Codex P1 / Devin BUG fixed in review-loop 3 commit 3cae293).
+          return NextResponse.json(
+            { received: false, status: "in_progress" },
+            { status: 503 }
+          );
+        }
       }
       // status === 'failed' → re-claim by flipping back to 'processing'.
       // (review-loop 2, P1) .select() で affected row 数を確認し、

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -217,11 +217,15 @@ export async function POST(request: Request) {
         );
       }
       // status === 'failed' → re-claim by flipping back to 'processing'.
-      const { error: reclaimError } = await dedupeAdmin
+      // (review-loop 2, P1) .select() で affected row 数を確認し、
+      // 同時 retry が 2件 'failed' を見て両方 reclaim を試みた race を防ぐ。
+      // 1件だけが update できる (もう1件は 0 rows = 別 worker が先に reclaim 済)。
+      const { data: reclaimed, error: reclaimError } = await dedupeAdmin
         .from("processed_stripe_events")
         .update({ status: "processing", last_error: null })
         .eq("event_id", event.id)
-        .eq("status", "failed");
+        .eq("status", "failed")
+        .select("event_id");
       if (reclaimError) {
         console.error(
           "[stripe/webhook] failed to re-claim failed event:",
@@ -230,6 +234,13 @@ export async function POST(request: Request) {
         return NextResponse.json(
           { error: "Idempotency ledger reclaim failed" },
           { status: 500 }
+        );
+      }
+      if (!reclaimed || reclaimed.length === 0) {
+        // Another worker reclaimed in the meantime — treat as in-progress.
+        return NextResponse.json(
+          { received: true, status: "in_progress" },
+          { status: 202 }
         );
       }
       claimedNew = true;

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +22,10 @@ export async function PATCH(
 ) {
   const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
+
+  // Auth + CSRF gate (P1-2).
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
 
   const { id } = await params;
 
@@ -46,22 +51,6 @@ export async function PATCH(
         { status: 400 }
       );
     }
-  }
-
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   // タスクが自分の組織のものか確認
@@ -128,23 +117,12 @@ export async function DELETE(
   const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
   if (limited) return limited;
 
+  // Auth + CSRF gate (P1-2). Critical for DELETE — CSRF would let a malicious
+  // origin trigger task deletion in a logged-in user's tab.
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
+
   const { id } = await params;
-
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
 
   // タスクが自分の組織のものか確認
   const { data: existing } = await supabase

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { requireAuth } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -47,21 +48,10 @@ export async function GET(request: Request) {
   const limited = await applyRateLimit(request, { limit: 30, windowMs: 60_000 });
   if (limited) return limited;
 
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  // Auth + CSRF gate (P1-2). GET is in checkCsrf scope too — Origin is
+  // typically present on cross-origin fetches even without credentials.
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
 
   const orgId = await getOrgId(supabase, user.id);
   if (!orgId) {
@@ -87,6 +77,10 @@ export async function POST(request: Request) {
   const limited = await applyRateLimit(request, { limit: 10, windowMs: 60_000 });
   if (limited) return limited;
 
+  // Auth + CSRF gate (P1-2).
+  const { user, supabase, error: authError } = await requireAuth(request);
+  if (authError) return authError;
+
   let body: Partial<CreateTaskBody>;
   try {
     body = (await request.json()) as Partial<CreateTaskBody>;
@@ -105,22 +99,6 @@ export async function POST(request: Request) {
       { error: `priority must be one of: ${VALID_PRIORITIES.join(", ")}` },
       { status: 400 }
     );
-  }
-
-  let supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createClient>>;
-  try {
-    const { createClient } = await import("@/lib/supabase/server");
-    supabase = await createClient();
-  } catch {
-    return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
-  }
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const orgId = await getOrgId(supabase, user.id);

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -51,17 +51,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         .eq("id", uid)
         .single();
       if (data?.plan) {
-        // trial_ends_at が過去の場合は free にフォールバック
+        // trial_ends_at が過去の場合は in-memory で free にフォールバック。
+        // DB 側の `plan` 列は migration 013 で authenticated に対する UPDATE が
+        // revoke されている (billing-bypass 防止) ため、ここから `update({plan})`
+        // を発行すると silent fail し、ユーザー体験は free だが DB は trial 値の
+        // ままドリフトする。DB の修正は server-side cron `/api/cron/trial-expiry`
+        // が SECURITY DEFINER 関数 `downgrade_expired_trials()` で行う。
         const isExpired =
           data.trial_ends_at != null &&
           new Date(data.trial_ends_at as string) < new Date();
         if (isExpired && data.plan !== "free") {
           setPlan("free");
-          // 次回読み込み高速化のため DB も更新
-          await supabase
-            .from("profiles")
-            .update({ plan: "free" })
-            .eq("id", uid);
         } else {
           setPlan((data.plan as PlanTier) || "free");
         }

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -47,11 +47,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const supabase = createClient();
       const { data } = await supabase
         .from("profiles")
-        .select("plan, trial_ends_at")
+        .select("plan, trial_ends_at, subscription_status")
         .eq("id", uid)
         .single();
       if (data?.plan) {
-        // trial_ends_at が過去の場合は in-memory で free にフォールバック。
+        // trial_ends_at が過去でも、subscription_status が paid (active /
+        // trialing / past_due) なら downgrade しない (CodeRabbit Major):
+        // Stripe webhook で trial→paid の遷移後に subscription_status だけが
+        // 'active' に更新され trial_ends_at は古いまま残るケースがあり、
+        // その場合に UI を強制 'free' にするとユーザーは突然有料機能が
+        // 使えなくなる (server は paid アクセスを継続維持しているのに UI
+        // 側だけ食い違う)。
+        //
         // DB 側の `plan` 列は migration 013 で authenticated に対する UPDATE が
         // revoke されている (billing-bypass 防止) ため、ここから `update({plan})`
         // を発行すると silent fail し、ユーザー体験は free だが DB は trial 値の
@@ -60,7 +67,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const isExpired =
           data.trial_ends_at != null &&
           new Date(data.trial_ends_at as string) < new Date();
-        if (isExpired && data.plan !== "free") {
+        const subStatus = (
+          data as { subscription_status?: string | null }
+        ).subscription_status;
+        const hasPaidStatus =
+          subStatus === "active" ||
+          subStatus === "trialing" ||
+          subStatus === "past_due";
+        if (isExpired && data.plan !== "free" && !hasPaidStatus) {
           setPlan("free");
         } else {
           setPlan((data.plan as PlanTier) || "free");

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,15 +1,20 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
-import type { User } from "@supabase/supabase-js";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
 
-type AuthSuccess = { user: User; error: null };
-type AuthFailure = { user: null; error: NextResponse };
+type SsrSupabase = Awaited<ReturnType<typeof createClient>>;
+
+type AuthSuccess = { user: User; supabase: SsrSupabase; error: null };
+type AuthFailure = { user: null; supabase: null; error: NextResponse };
 
 /** Plan hierarchy: free < pro < business */
 export type Plan = "free" | "pro" | "business";
 
-type PlanSuccess = { user: User; plan: Plan; error: null };
-type PlanFailure = { user: null; plan: null; error: NextResponse };
+type PlanSuccess = { user: User; supabase: SsrSupabase; plan: Plan; error: null };
+type PlanFailure = { user: null; supabase: null; plan: null; error: NextResponse };
+
+// Re-export for downstream typing convenience.
+export type { SupabaseClient };
 
 const PLAN_ORDER: Record<Plan, number> = { free: 0, pro: 1, business: 2 };
 
@@ -65,15 +70,16 @@ export async function requireAuth(request: Request): Promise<AuthSuccess | AuthF
   // CSRF チェック
   const csrfError = checkCsrf(request);
   if (csrfError) {
-    return { user: null, error: csrfError };
+    return { user: null, supabase: null, error: csrfError };
   }
 
-  let supabase: Awaited<ReturnType<typeof createClient>>;
+  let supabase: SsrSupabase;
   try {
     supabase = await createClient();
   } catch {
     return {
       user: null,
+      supabase: null,
       error: NextResponse.json({ error: "Supabase not configured" }, { status: 503 }),
     };
   }
@@ -86,11 +92,12 @@ export async function requireAuth(request: Request): Promise<AuthSuccess | AuthF
   if (authError || !user) {
     return {
       user: null,
+      supabase: null,
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
     };
   }
 
-  return { user, error: null };
+  return { user, supabase, error: null };
 }
 
 /**
@@ -109,20 +116,9 @@ export async function requirePlan(
 ): Promise<PlanSuccess | PlanFailure> {
   const authResult = await requireAuth(request);
   if (authResult.error) {
-    return { user: null, plan: null, error: authResult.error };
+    return { user: null, supabase: null, plan: null, error: authResult.error };
   }
-  const { user } = authResult;
-
-  let supabase: Awaited<ReturnType<typeof createClient>>;
-  try {
-    supabase = await createClient();
-  } catch {
-    return {
-      user: null,
-      plan: null,
-      error: NextResponse.json({ error: "Supabase not configured" }, { status: 503 }),
-    };
-  }
+  const { user, supabase } = authResult;
 
   const { data: profile, error: profileError } = await supabase
     .from("profiles")
@@ -134,6 +130,7 @@ export async function requirePlan(
     console.error("[requirePlan] Profile fetch error:", profileError.message);
     return {
       user: null,
+      supabase: null,
       plan: null,
       error: NextResponse.json({ error: "Failed to verify plan" }, { status: 500 }),
     };
@@ -144,6 +141,7 @@ export async function requirePlan(
   if (PLAN_ORDER[userPlan] < PLAN_ORDER[requiredPlan]) {
     return {
       user: null,
+      supabase: null,
       plan: null,
       error: NextResponse.json(
         { error: `Plan upgrade required. This endpoint requires '${requiredPlan}' or higher.` },
@@ -152,5 +150,5 @@ export async function requirePlan(
     };
   }
 
-  return { user, plan: userPlan, error: null };
+  return { user, supabase, plan: userPlan, error: null };
 }

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -19,35 +19,68 @@ export type { SupabaseClient };
 const PLAN_ORDER: Record<Plan, number> = { free: 0, pro: 1, business: 2 };
 
 /**
- * CSRF保護: リクエストのOriginヘッダーをNEXT_PUBLIC_SITE_URLと比較する。
+ * CSRF保護: リクエストの Origin ヘッダーを allowlist と比較する。
  *
- * Stripe webhookおよびcronルート（/api/stripe/webhook, /api/cron/）は
- * OriginヘッダーがないためCSRFチェックをスキップする。
+ * Allowlist:
+ *   - 必須: `NEXT_PUBLIC_SITE_URL` (production / 全環境)
+ *   - 非本番のみ: `VERCEL_URL` (preview/staging deployment の ephemeral
+ *     `*.vercel.app` ドメイン。server-only env で改竄不可)
+ *
+ * production (`VERCEL_ENV='production'`) では `NEXT_PUBLIC_SITE_URL` のみ
+ * 厳格一致。VERCEL_ENV 未設定 (self-host) では NODE_ENV='production' で
+ * fallback 判定 (checkout/route.ts と整合)。
+ *
+ * Stripe webhook および cron ルート (/api/stripe/webhook, /api/cron/) は
+ * Origin ヘッダーがないため CSRF チェックをスキップする。
  *
  * @returns 403 Response if Origin is invalid, null if OK
  */
 function checkCsrf(request: Request): NextResponse | null {
   const url = new URL(request.url);
-  // stripe webhook と cron はサーバー間リクエストのためOriginなし — スキップ
+  // stripe webhook と cron はサーバー間リクエストのため Origin なし — スキップ
   const skipPaths = ["/api/stripe/webhook", "/api/cron/"];
   if (skipPaths.some((p) => url.pathname.startsWith(p))) {
     return null;
   }
 
   const origin = request.headers.get("origin");
-  // Originヘッダーなし（サーバー間・curlなど）は通過させる
+  // Origin ヘッダーなし (サーバー間・curl など) は通過させる
   if (!origin) return null;
 
+  const allowed = new Set<string>();
+
+  // Primary allowlist: NEXT_PUBLIC_SITE_URL (production canonical domain).
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://faultray.com";
-  let expectedOrigin: string;
   try {
-    expectedOrigin = new URL(siteUrl).origin;
+    allowed.add(new URL(siteUrl).origin);
   } catch {
-    // NEXT_PUBLIC_SITE_URL が不正な場合はスキップ（設定ミス時に全リクエストを弾かないよう）
+    // malformed env — fall through; if VERCEL_URL も無ければ後続で fail-open
+  }
+
+  // Non-production-only: VERCEL_URL (preview/staging deployment domain).
+  // Production を VERCEL_ENV で判定するのは checkout/route.ts と同じ理由
+  // (preview build も NODE_ENV='production' になるため NODE_ENV だけでは
+  // 区別不能)。VERCEL_ENV 未設定 (Vercel 外 self-host) は NODE_ENV fallback。
+  const vercelEnv = process.env.VERCEL_ENV;
+  const isProduction = vercelEnv
+    ? vercelEnv === "production"
+    : process.env.NODE_ENV === "production";
+  if (!isProduction && process.env.VERCEL_URL) {
+    try {
+      allowed.add(new URL(`https://${process.env.VERCEL_URL}`).origin);
+    } catch {
+      // ignore
+    }
+  }
+
+  if (allowed.size === 0) {
+    // 設定 mis でいかなる allowlist も組み立てられない → fail-open
+    // (production で NEXT_PUBLIC_SITE_URL が malformed だと全 request 403 に
+    //  なるのを避ける従来挙動を維持)
     return null;
   }
 
-  if (origin !== expectedOrigin) {
+  if (!allowed.has(origin)) {
     return NextResponse.json(
       { error: "Forbidden: Origin mismatch" },
       { status: 403 }

--- a/supabase/migrations/013_security_hardening.sql
+++ b/supabase/migrations/013_security_hardening.sql
@@ -1,0 +1,271 @@
+-- 013: Security hardening — Codex audit 2026-04-30 findings
+-- ----------------------------------------------------------------------------
+-- 監査結果 (4並列 codex-auto-review):
+--   P0-1  apm_* policies が TO service_role 不在で PUBLIC 適用 → 全テナント read/write
+--   P1-1  profiles の UPDATE が列無制限 → ユーザー自身で plan='business' に書き換え可能 (billing bypass)
+--   P1-7  "Admins can invite" の WITH CHECK が値無制限 → admin が role='owner', status='active' を直接 INSERT で承諾フローバイパス
+--   P1-8  teams の UPDATE が列無制限 → 非owner admin が owner_id/plan/stripe_* 書き換え可能
+--   P1-9  user_team_ids(uid)/user_admin_team_ids(uid) が任意 UID を anon/authenticated に EXECUTE 許可 → 他人のチーム列挙可能
+--   P1-4  Stripe webhook に event.id dedup 用の processed_stripe_events テーブルなし
+--
+-- 設計方針:
+--   - 列単位 GRANT を導入。billing 関連列 (plan/subscription_status/stripe_*/trial_ends_at) は
+--     service_role のみ UPDATE 可能。Stripe webhook と coupon/redeem は service_role 経由で更新する
+--     ように route 側を変更する (PR の別コミット)。
+--   - SECURITY DEFINER 関数は `auth.uid()` を内部バインドするゼロ引数版に置き換える。旧版は drop。
+--   - org_members "Admins can invite" は status='pending' を強制し、role を 'member'/'admin' に制限。
+--     owner 昇格は service_role 経由のみ。
+-- ----------------------------------------------------------------------------
+
+-- ============================================================================
+-- P0-1: APM tables — restrict policies to service_role only
+-- ============================================================================
+drop policy if exists "Service role full access" on public.apm_agents;
+drop policy if exists "Service role full access" on public.apm_metrics;
+drop policy if exists "Service role full access" on public.apm_alerts;
+
+create policy "Service role full access" on public.apm_agents
+  for all to service_role using (true) with check (true);
+create policy "Service role full access" on public.apm_metrics
+  for all to service_role using (true) with check (true);
+create policy "Service role full access" on public.apm_alerts
+  for all to service_role using (true) with check (true);
+
+-- Defense in depth: revoke direct table grants from anon/authenticated.
+-- (RLS alone gives empty result set; revoke prevents UPDATE/DELETE attempts even
+--  via raw HTTP if a future policy bug re-opens it.)
+revoke all on public.apm_agents  from anon, authenticated;
+revoke all on public.apm_metrics from anon, authenticated;
+revoke all on public.apm_alerts  from anon, authenticated;
+
+-- ============================================================================
+-- P1-1: profiles — column-level UPDATE GRANT (billing bypass prevention)
+-- ============================================================================
+-- Strategy: revoke table-level UPDATE, then re-grant only for non-sensitive columns.
+-- Sensitive columns (must NOT be user-writable): plan, subscription_status,
+-- stripe_customer_id, stripe_subscription_id, trial_ends_at.
+-- These are written exclusively by service_role (Stripe webhook + coupon redeem
+-- after route refactor).
+
+revoke update on public.profiles from anon, authenticated;
+
+-- Re-grant UPDATE on non-sensitive columns only.
+-- NOTE: column list is derived from 001/003/007/012 migrations. If new
+-- non-sensitive columns are added later, extend this GRANT in a follow-up
+-- migration.
+grant update (
+  email,
+  full_name,
+  avatar_url,
+  notification_preferences
+) on public.profiles to authenticated;
+
+-- ============================================================================
+-- P1-8: teams — column-level UPDATE GRANT
+-- ============================================================================
+-- Sensitive (service_role only): owner_id, plan, stripe_customer_id,
+-- stripe_subscription_id.
+revoke update on public.teams from anon, authenticated;
+
+-- Re-grant UPDATE on non-sensitive columns. Adjust if 001 schema differs.
+grant update (
+  name
+) on public.teams to authenticated;
+
+-- ============================================================================
+-- P1-7: org_members — Tighten "Admins can invite" WITH CHECK
+-- ============================================================================
+-- Old policy allowed admin to insert any role/status. New policy:
+--   - status MUST be 'pending' (no direct active membership)
+--   - role MUST be 'member' / 'admin' / 'viewer' (no owner promotion)
+-- Owner promotion is moved to service_role-backed RPC (followup).
+-- (VALID_ROLES at src/app/api/org/invite/route.ts is ['admin','member','viewer'].)
+drop policy if exists "Admins can invite" on public.org_members;
+create policy "Admins can invite"
+  on public.org_members
+  for insert
+  with check (
+    status = 'pending'
+    and role in ('member', 'admin', 'viewer')
+    and (
+      org_id in (
+        select om.org_id
+        from public.org_members om
+        where om.user_id = auth.uid()
+          and om.role = any (array['owner', 'admin'])
+          and om.status = 'active'
+      )
+      or org_id in (
+        select o.id
+        from public.organizations o
+        where o.owner_id = auth.uid()
+      )
+    )
+  );
+
+-- Separate policy for org owner self-bootstrap (creating an org and
+-- inserting themselves as 'owner' / 'active'). Restricted to inserter being
+-- the org's owner_id and the row referring to the same auth.uid().
+drop policy if exists "Org owners can self-bootstrap as active" on public.org_members;
+create policy "Org owners can self-bootstrap as active"
+  on public.org_members
+  for insert
+  with check (
+    user_id = auth.uid()
+    and role = 'owner'
+    and status = 'active'
+    and org_id in (
+      select o.id
+      from public.organizations o
+      where o.owner_id = auth.uid()
+    )
+  );
+
+-- ============================================================================
+-- P1-9: user_team_ids/user_admin_team_ids — bind auth.uid() internally
+-- ============================================================================
+-- Old (006) signature: user_team_ids(uid uuid). The uid argument lets any
+-- authenticated user enumerate any other user's team membership. We replace
+-- with zero-arg versions that read auth.uid() internally, then update all
+-- policies that reference the old signature.
+
+-- Step 1: create zero-arg versions
+create or replace function public.user_team_ids()
+returns setof uuid
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select team_id from public.team_members where user_id = auth.uid()
+$$;
+
+create or replace function public.user_admin_team_ids()
+returns setof uuid
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select team_id from public.team_members
+  where user_id = auth.uid() and role in ('owner', 'admin')
+$$;
+
+revoke execute on function public.user_team_ids()        from public, anon;
+revoke execute on function public.user_admin_team_ids()  from public, anon;
+grant  execute on function public.user_team_ids()        to authenticated;
+grant  execute on function public.user_admin_team_ids()  to authenticated;
+
+-- Step 2: re-create all policies that referenced the (uuid) signature.
+-- (Mirrors 006_fix_rls_recursion.sql.)
+
+drop policy if exists "Members can view team members" on public.team_members;
+create policy "Members can view team members"
+  on public.team_members for select
+  using (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team admins can insert team members" on public.team_members;
+create policy "Team admins can insert team members"
+  on public.team_members for insert
+  with check (team_id in (select public.user_admin_team_ids()));
+
+drop policy if exists "Team admins can update team members" on public.team_members;
+create policy "Team admins can update team members"
+  on public.team_members for update
+  using (team_id in (select public.user_admin_team_ids()));
+
+drop policy if exists "Team admins can delete team members" on public.team_members;
+create policy "Team admins can delete team members"
+  on public.team_members for delete
+  using (
+    user_id = auth.uid()
+    or team_id in (select public.user_admin_team_ids())
+  );
+
+drop policy if exists "Team members can view teams" on public.teams;
+create policy "Team members can view teams"
+  on public.teams for select
+  using (id in (select public.user_team_ids()));
+
+drop policy if exists "Team owner can update team" on public.teams;
+create policy "Team owner can update team"
+  on public.teams for update
+  using (id in (select public.user_admin_team_ids()));
+
+drop policy if exists "Team members can view projects" on public.projects;
+create policy "Team members can view projects"
+  on public.projects for select
+  using (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team members can create projects" on public.projects;
+create policy "Team members can create projects"
+  on public.projects for insert
+  with check (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team members can update projects" on public.projects;
+create policy "Team members can update projects"
+  on public.projects for update
+  using (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team admins can delete projects" on public.projects;
+create policy "Team admins can delete projects"
+  on public.projects for delete
+  using (team_id in (select public.user_admin_team_ids()));
+
+drop policy if exists "Team members can view runs" on public.simulation_runs;
+create policy "Team members can view runs"
+  on public.simulation_runs for select
+  using (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team members can create runs" on public.simulation_runs;
+create policy "Team members can create runs"
+  on public.simulation_runs for insert
+  with check (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team admins can delete runs" on public.simulation_runs;
+create policy "Team admins can delete runs"
+  on public.simulation_runs for delete
+  using (team_id in (select public.user_admin_team_ids()));
+
+drop policy if exists "Team members can view usage" on public.usage;
+create policy "Team members can view usage"
+  on public.usage for select
+  using (team_id in (select public.user_team_ids()));
+
+drop policy if exists "Team admins can view billing" on public.billing_events;
+create policy "Team admins can view billing"
+  on public.billing_events for select
+  using (team_id in (select public.user_admin_team_ids()));
+
+-- Step 3: drop the old (uuid)-arg versions
+drop function if exists public.user_team_ids(uuid);
+drop function if exists public.user_admin_team_ids(uuid);
+
+-- ============================================================================
+-- P1-4: Stripe webhook idempotency table
+-- ============================================================================
+-- processed_stripe_events stores Stripe event.id with UNIQUE constraint so
+-- the webhook handler can `INSERT ... ON CONFLICT DO NOTHING` and skip
+-- duplicates atomically. Optional last_event_at column lets us reject
+-- out-of-order events per customer.
+create table if not exists public.processed_stripe_events (
+  event_id     text primary key,
+  event_type   text not null,
+  customer_id  text,
+  processed_at timestamptz not null default now()
+);
+
+create index if not exists idx_processed_stripe_events_customer
+  on public.processed_stripe_events (customer_id, processed_at desc);
+
+alter table public.processed_stripe_events enable row level security;
+
+-- service_role only (webhook is server-side and uses service_role key).
+drop policy if exists "service_role manages stripe events"
+  on public.processed_stripe_events;
+create policy "service_role manages stripe events"
+  on public.processed_stripe_events
+  for all to service_role
+  using (true) with check (true);
+
+revoke all on public.processed_stripe_events from anon, authenticated;

--- a/supabase/migrations/013_security_hardening.sql
+++ b/supabase/migrations/013_security_hardening.sql
@@ -151,10 +151,17 @@ as $$
   where user_id = auth.uid() and role in ('owner', 'admin')
 $$;
 
-revoke execute on function public.user_team_ids()        from public, anon;
-revoke execute on function public.user_admin_team_ids()  from public, anon;
-grant  execute on function public.user_team_ids()        to authenticated;
-grant  execute on function public.user_admin_team_ids()  to authenticated;
+revoke execute on function public.user_team_ids()        from public;
+revoke execute on function public.user_admin_team_ids()  from public;
+-- anon role must retain EXECUTE so that RLS policies referencing these
+-- functions (teams / team_members / projects / simulation_runs / usage /
+-- billing_events) can be evaluated for unauthenticated requests. Without it,
+-- a `select * from teams` from anon raises `permission denied for function
+-- user_team_ids` before RLS can silently filter to 0 rows. SECURITY DEFINER
+-- + auth.uid() (NULL for anon) → the function returns an empty set, so
+-- granting to anon does not enable enumeration.
+grant execute on function public.user_team_ids()        to authenticated, anon;
+grant execute on function public.user_admin_team_ids()  to authenticated, anon;
 
 -- Step 2: re-create all policies that referenced the (uuid) signature.
 -- (Mirrors 006_fix_rls_recursion.sql.)

--- a/supabase/migrations/014_stripe_event_status.sql
+++ b/supabase/migrations/014_stripe_event_status.sql
@@ -1,0 +1,45 @@
+-- 014: Stripe event ledger を 2-state (processing → processed) に拡張
+-- ----------------------------------------------------------------------------
+-- 背景:
+--   013 で processed_stripe_events table を追加し、webhook 受信時に
+--   INSERT-on-conflict で dedup していた。しかし side effect (updateUserPlan
+--   等) が throw した場合、event は永久に dedup された状態で残り、Stripe の
+--   retry が duplicate として skip → billing state が壊れたまま固定。
+--
+--   Codex review (PR #89) の P1 指摘:
+--     "do not make the event permanently deduped before successful handling"
+--
+-- 設計:
+--   - status カラムを追加: 'processing' | 'processed' | 'failed'
+--   - webhook 受信時: INSERT (event_id, status='processing') ON CONFLICT DO NOTHING
+--     - INSERT 成功 (= 新規 event) → 通常処理 → 成功時 UPDATE status='processed'
+--     - INSERT 衝突 (= 重複) → 既存 status を check:
+--         processed → 200 duplicate
+--         processing → 別 worker が処理中、202 accepted
+--         failed     → 再処理 (UPDATE status='processing')
+--   - 失敗時: row を DELETE (Stripe が retry できる)
+--   - 既存 row は status='processed' 扱い (既に side effect 完了している前提)
+-- ----------------------------------------------------------------------------
+
+alter table public.processed_stripe_events
+  add column if not exists status text not null default 'processed'
+    check (status in ('processing', 'processed', 'failed'));
+
+alter table public.processed_stripe_events
+  add column if not exists last_error text;
+
+alter table public.processed_stripe_events
+  add column if not exists updated_at timestamptz not null default now();
+
+-- updated_at auto-bump trigger (003 の set_updated_at を再利用)
+drop trigger if exists set_processed_stripe_events_updated_at
+  on public.processed_stripe_events;
+create trigger set_processed_stripe_events_updated_at
+  before update on public.processed_stripe_events
+  for each row
+  execute function public.set_updated_at();
+
+-- Index for the rare 'failed' / 'processing' lookup paths
+create index if not exists idx_processed_stripe_events_status
+  on public.processed_stripe_events (status, processed_at desc)
+  where status <> 'processed';

--- a/supabase/migrations/014_stripe_event_status.sql
+++ b/supabase/migrations/014_stripe_event_status.sql
@@ -14,10 +14,11 @@
 --   - webhook 受信時: INSERT (event_id, status='processing') ON CONFLICT DO NOTHING
 --     - INSERT 成功 (= 新規 event) → 通常処理 → 成功時 UPDATE status='processed'
 --     - INSERT 衝突 (= 重複) → 既存 status を check:
---         processed → 200 duplicate
---         processing → 別 worker が処理中、202 accepted
+--         processed  → 200 duplicate (Stripe は retry を止める)
+--         processing → 503 (worker crash 残留時に Stripe retry が止まらないように)
 --         failed     → 再処理 (UPDATE status='processing')
---   - 失敗時: row を DELETE (Stripe が retry できる)
+--   - side effect 失敗時: UPDATE status='failed', last_error 記録 → 500 return
+--     (Stripe retry が来た時に上記 'failed' branch で reclaim される)
 --   - 既存 row は status='processed' 扱い (既に side effect 完了している前提)
 -- ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## 概要

Codex (`codex-auto-review` model) を 4 並列実行した security audit (2026-04-30) で検出された 19件の finding のうち、**最も影響度が高い 8 件 + 1 idempotency table** を本 PR で fix する。残りは follow-up issue として #79-#88 (P1/P2/P3) と #78 (URGENT manual: token rotation) で tracking。

Epic: #77

## このPRで fix するもの

| Severity | Item | Fix |
|---|---|---|
| **P0-1** | apm_* RLS が PUBLIC 適用 = 全テナント read/write | migration 013: `TO service_role` 追加 + REVOKE table grants |
| **P1-1** | profiles の `plan`/`subscription_status`/`stripe_*`/`trial_ends_at` を user role が SQL で直書き換え可能 (Billing Bypass) | migration 013: 列単位 GRANT で user role を非 sensitive 列のみに制限 + coupon/redeem を service_role 経由に切替 |
| **P1-2** | 8 routes が `requireAuth()` を bypass して CSRF gate を skip | account/delete, coupon/redeem, org/create, org/invite, stripe/checkout, tasks (POST/PATCH/DELETE) を `requireAuth(request)` に統一 |
| **P1-4** | Stripe webhook に event.id dedup なし (replay/idempotency 問題) | migration 013: `processed_stripe_events` table 追加 + webhook で INSERT-on-conflict |
| **P1-7** | org_members "Admins can invite" の WITH CHECK が値無制限 → admin が role='owner' を直接 INSERT | migration 013: `status='pending' AND role IN ('member','admin','viewer')` に強化 |
| **P1-8** | teams で非owner admin が owner_id/billing 列を更新可能 | migration 013: 列単位 GRANT で sensitive 列を service_role only に |
| **P1-9** | `user_team_ids(uid)` SECURITY DEFINER が任意 UID を anon EXECUTE 可能 = 他人のチーム列挙 | migration 013: 引数なし + auth.uid() 内部バインドの zero-arg version に置換 (14 policies 再 create) |
| **P2-1** | stripe/checkout が Origin を success/cancel_url に reflect → phishing redirect | request.headers.get('origin') を捨てて `NEXT_PUBLIC_SITE_URL` 固定 |

## 未対応 (follow-up issues)

| Severity | Issue | 内容 |
|---|---|---|
| **URGENT** | #78 | `.env.local` / `.env.staging.local` の **実トークン rotation** (manual action) |
| P1-3 | #79 | Stripe webhook metadata.user_id 盲信 → customer_id source-of-truth 化 (大改修、別 PR) |
| P2-2 | #80 | tasks.assignee_id cross-tenant assign |
| P2-3 | #81 | Stripe customer-not-mapped silent 200 |
| P2-4 | #82 | Stripe webhook TOCTOU / last-write-wins |
| P2-6 | #83 | member_systems cross-tenant relation |
| P2-7 | #84 | ENCRYPTION_KEY fail-fast (現状 unused) |
| P2-8 | #85 | CSP nonce-based script-src |
| P3-1 | #86 | /api/status auth gate or coarse public status |
| P3-3 | #87 | .secrets.baseline がローカル env files カバーせず |
| P3-4 | #88 | CORS allowlist を server-only env に |

(既存 #70 / #75 は Codex でも独立検出 = 真陽性確定。本 PR では触れない。)

## 検証

```
$ npx tsc --noEmit          # ✅ clean
$ npm run lint              # ✅ clean
$ npm run test:unit         # ⚠️ pre-existing vitest config ESM/CJS error (unrelated to this PR)
```

`requireAuth` の戻り値型が `{ user, supabase, error }` に変わった (以前は `{ user, error }`)。8 routes 全部の destructuring を新 shape に揃えた。

## 監査 artifact

- `/tmp/audit-A-auth.md` (15 API routes — auth/CSRF/IDOR)
- `/tmp/audit-B-stripe.md` (Stripe webhook — signature/replay/idempotency)
- `/tmp/audit-C-rls.md` (12 Supabase migrations — RLS/SECURITY DEFINER)
- `/tmp/audit-D-secrets.md` (env/CSP/CORS — secrets exposure)

## 補足: 外部からの cold sales 対応

`hydralaunch.com` / `tryargus.dev` (Hydra 社の Argus ブランド) の **Elara Whitfield** から「light scan を実行した」と主張する cold email が来たが、Codex 並列監査で**それを上回るカテゴリの finding (内部 billing bypass, RLS misconfig, payment replay) まで自前取得済**。$100 払う価値なし。

## 影響度

- **migration 013 適用後**:
  - APM テーブルへの匿名アクセス遮断
  - SQL 直書きによる plan/billing 改竄の阻止
  - Stripe webhook の replay 攻撃に対する idempotency
  - org/team での権限昇格パスの遮断
- **route 変更後**:
  - 全 state-changing API endpoint で CSRF gate 強制
  - stripe/checkout の post-payment redirect 偽装阻止

Co-Authored-By: Claude Opus 4.7 (1M context)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray-app/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Unified authentication/CSRF gate across APIs; stricter Stripe redirect origin validation; DB RLS hardening and new webhook dedupe ledger.

* **Bug Fixes**
  * Idempotent Stripe webhook processing with retry/reclaim semantics; safer coupon redemption with optimistic increment and rollback; improved error handling for missing server config.

* **Refactor**
  * Auth flow now supplies a shared server client to handlers.

* **Chores**
  * Updated secrets baseline and refreshed generation timestamp; moved trial-downgrade persistence to server-side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->