### PR TITLE
ops: switch Slack notifications to threaded chat.postMessage

### DIFF
--- a/.github/workflows/notify-pipeline.yml
+++ b/.github/workflows/notify-pipeline.yml
@@ -2,23 +2,32 @@ name: Notify pipeline events to Slack
 
 # 目的:
 #   PR review pipeline (CI / Vercel / CodeRabbit / Codex / Devin Review) と
-#   PR lifecycle (open/close/merge) の状態を 1 つの Slack channel に統合通知する。
+#   PR lifecycle (open/close/merge) を Slack channel に **スレッド** で通知する。
+#   PR opened を親メッセージにし、それ以降の event (synchronize / review /
+#   check_suite / merge / close) を全て同 PR の thread 返信として post する。
 #
 # 必要な GitHub repo 設定:
-#   - Settings → Variables → Actions: ENABLE_SLACK_NOTIFICATIONS = "true"
-#   - Settings → Secrets → Actions: SLACK_WEBHOOK_URL = (Slack Incoming Webhook の URL)
+#   - Variables → Actions: ENABLE_SLACK_NOTIFICATIONS = "true"
+#   - Secrets   → Actions: SLACK_BOT_TOKEN          (Slack app の Bot User OAuth Token, xoxb-...)
+#   - Secrets   → Actions: SLACK_CHANNEL_ID         (通知先 channel の ID, C0XXXXXXXX)
 #
 # Slack 側設定:
-#   1. https://api.slack.com/apps から新 app 作成 ("FaultRay PR Pipeline" など)
-#   2. Incoming Webhooks を有効化 → 通知先 channel を指定して webhook URL 取得
-#   3. その URL を SLACK_WEBHOOK_URL secret に登録
+#   1. https://api.slack.com/apps から既存 / 新 app を開く
+#   2. OAuth & Permissions → Bot Token Scopes に追加:
+#        - chat:write
+#        - chat:write.public  (招待されていない public channel にも投稿)
+#   3. Install to Workspace で再インストール、Bot User OAuth Token をコピー
+#   4. 通知先 channel 名を右クリック → channel ID コピー
+#   5. SLACK_BOT_TOKEN / SLACK_CHANNEL_ID を GitHub secrets に登録
 #
-# 通知トリガー:
-#   - pull_request: opened / reopened / closed / synchronize / ready_for_review
-#   - pull_request_review: submitted (CodeRabbit/Codex/Devin/人間)
-#   - issue_comment: created (bot review コメントのみ。人間コメントは通知しない)
-#   - check_suite: completed (GitHub Actions / Vercel)
-#   - workflow_run: completed (CI workflow のみ)
+# Threading 仕組み:
+#   - PR opened/reopened/ready_for_review:
+#       chat.postMessage で post → 返り値の ts を取得
+#       → PR body 末尾に <!-- slack-thread-ts: NNN.MMM --> として書き込み
+#   - その他のイベント:
+#       PR body から marker を読み出して thread_ts として指定
+#       → スレッド返信として post
+#       (marker が無い fallback では flat に post)
 
 on:
   pull_request:
@@ -35,29 +44,44 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write  # PR body に thread_ts marker を書き込むため
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    # ENABLE_SLACK_NOTIFICATIONS=true でないと skip。secret 未登録 repo を保護。
     if: ${{ vars.ENABLE_SLACK_NOTIFICATIONS == 'true' }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
     steps:
-      - name: Filter bot-only events
+      # ── secret 未登録 repo を保護 ────────────────────────────────────────
+      - name: Verify secrets
+        id: secrets_check
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL_ID" ]; then
+            echo "::warning::SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not set; skipping notify"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── 人間 issue_comment は通知しない (bot review のみ) ──────────────
+      - name: Filter bot-only issue_comments
         id: filter
+        if: ${{ steps.secrets_check.outputs.skip != 'true' }}
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_USER: ${{ github.event.comment.user.login }}
           IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
         run: |
-          # issue_comment は bot のみ通知。人間 / non-PR comment はスキップ。
           if [ "$EVENT_NAME" = "issue_comment" ]; then
             if [ "$IS_PR_COMMENT" != "true" ]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             case "$COMMENT_USER" in
-              coderabbitai|coderabbitai[bot]|chatgpt-codex-connector|chatgpt-codex-connector[bot]|devin-ai-integration|devin-ai-integration[bot])
+              coderabbitai|coderabbitai\[bot\]|chatgpt-codex-connector|chatgpt-codex-connector\[bot\]|devin-ai-integration|devin-ai-integration\[bot\])
                 echo "skip=false" >> "$GITHUB_OUTPUT"
                 ;;
               *)
@@ -68,17 +92,65 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build Slack payload
+      # ── PR 番号を event 別に解決 ────────────────────────────────────────
+      - name: Resolve PR number
+        id: pr
+        if: ${{ steps.secrets_check.outputs.skip != 'true' && steps.filter.outputs.skip != 'true' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_DIRECT: ${{ github.event.pull_request.number || github.event.issue.number }}
+          CHECK_SUITE_PR: ${{ toJson(github.event.check_suite.pull_requests) }}
+          WORKFLOW_RUN_PR: ${{ toJson(github.event.workflow_run.pull_requests) }}
+          HEAD_SHA: ${{ github.event.check_suite.head_sha || github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          PR=""
+          if [ -n "$PR_NUMBER_DIRECT" ] && [ "$PR_NUMBER_DIRECT" != "null" ]; then
+            PR="$PR_NUMBER_DIRECT"
+          elif [ "$EVENT_NAME" = "check_suite" ] && [ -n "$CHECK_SUITE_PR" ]; then
+            PR=$(echo "$CHECK_SUITE_PR" | jq -r '.[0].number // empty')
+          elif [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$WORKFLOW_RUN_PR" ]; then
+            PR=$(echo "$WORKFLOW_RUN_PR" | jq -r '.[0].number // empty')
+          fi
+
+          # フォールバック: head_sha から PR を逆引き
+          if [ -z "$PR" ] && [ -n "$HEAD_SHA" ] && [ "$HEAD_SHA" != "null" ]; then
+            PR=$(gh pr list --repo "$REPO" --state open --head-sha "$HEAD_SHA" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          fi
+
+          if [ -z "$PR" ]; then
+            echo "::warning::Could not resolve PR number for event $EVENT_NAME; will post flat"
+          fi
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      # ── PR body から既存の thread_ts marker を読み出す ─────────────────
+      - name: Read thread_ts from PR body
+        id: ts
+        if: ${{ steps.secrets_check.outputs.skip != 'true' && steps.filter.outputs.skip != 'true' }}
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          TS=""
+          if [ -n "$PR_NUMBER" ]; then
+            BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+            TS=$(printf '%s' "$BODY" | grep -oE 'slack-thread-ts: [0-9]+\.[0-9]+' | head -1 | awk '{print $2}' || true)
+          fi
+          echo "value=$TS" >> "$GITHUB_OUTPUT"
+
+      # ── Slack payload を build ─────────────────────────────────────────
+      - name: Build payload
         id: payload
-        if: ${{ steps.filter.outputs.skip != 'true' }}
+        if: ${{ steps.secrets_check.outputs.skip != 'true' && steps.filter.outputs.skip != 'true' }}
         env:
           EVENT_NAME: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
-          ACTOR: ${{ github.actor }}
           REVIEW_USER: ${{ github.event.review.user.login || github.event.comment.user.login }}
           REVIEW_STATE: ${{ github.event.review.state }}
           REVIEW_BODY: ${{ github.event.review.body || github.event.comment.body }}
@@ -90,15 +162,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -e
-
-          # ── イベント別 icon / title 決定 ──────────────────────────────
+          ICON=":mailbox:"; TITLE="event"; IS_PARENT="false"
           case "$EVENT_NAME" in
             pull_request)
               case "$ACTION" in
-                opened)       ICON=":sparkles:";       TITLE="PR opened" ;;
-                reopened)     ICON=":arrows_counterclockwise:"; TITLE="PR reopened" ;;
-                synchronize)  ICON=":arrow_up:";       TITLE="PR updated" ;;
-                ready_for_review) ICON=":eyes:";        TITLE="PR ready for review" ;;
+                opened)            ICON=":sparkles:";              TITLE="PR opened";       IS_PARENT="true"  ;;
+                reopened)          ICON=":arrows_counterclockwise:"; TITLE="PR reopened";   IS_PARENT="true"  ;;
+                ready_for_review)  ICON=":eyes:";                  TITLE="PR ready for review"; IS_PARENT="true" ;;
+                synchronize)       ICON=":arrow_up:";              TITLE="PR updated"        ;;
                 closed)
                   if [ "$PR_MERGED" = "true" ]; then
                     ICON=":tada:"; TITLE="PR merged"
@@ -106,19 +177,19 @@ jobs:
                     ICON=":wastebasket:"; TITLE="PR closed without merge"
                   fi
                   ;;
-                *)            ICON=":mailbox:";        TITLE="PR $ACTION" ;;
+                *)                 TITLE="PR $ACTION"             ;;
               esac
               ;;
             pull_request_review)
               case "$REVIEW_USER" in
                 coderabbitai*)             ICON=":rabbit:";      TITLE="CodeRabbit review" ;;
-                chatgpt-codex-connector*)  ICON=":robot_face:";  TITLE="Codex review" ;;
-                devin-ai-integration*)     ICON=":brain:";       TITLE="Devin Review" ;;
+                chatgpt-codex-connector*)  ICON=":robot_face:";  TITLE="Codex review"      ;;
+                devin-ai-integration*)     ICON=":brain:";       TITLE="Devin Review"      ;;
                 *)
                   case "$REVIEW_STATE" in
-                    approved)         ICON=":white_check_mark:"; TITLE="Approved by $REVIEW_USER" ;;
-                    changes_requested) ICON=":no_entry:";        TITLE="Changes requested by $REVIEW_USER" ;;
-                    *)                ICON=":speech_balloon:";   TITLE="Review by $REVIEW_USER" ;;
+                    approved)          ICON=":white_check_mark:"; TITLE="Approved by ${REVIEW_USER}" ;;
+                    changes_requested) ICON=":no_entry:";         TITLE="Changes requested by ${REVIEW_USER}" ;;
+                    *)                 ICON=":speech_balloon:";   TITLE="Review by ${REVIEW_USER}" ;;
                   esac
                   ;;
               esac
@@ -126,17 +197,17 @@ jobs:
             issue_comment)
               case "$REVIEW_USER" in
                 coderabbitai*)             ICON=":rabbit:";      TITLE="CodeRabbit comment" ;;
-                chatgpt-codex-connector*)  ICON=":robot_face:";  TITLE="Codex comment" ;;
-                devin-ai-integration*)     ICON=":brain:";       TITLE="Devin comment" ;;
+                chatgpt-codex-connector*)  ICON=":robot_face:";  TITLE="Codex comment"      ;;
+                devin-ai-integration*)     ICON=":brain:";       TITLE="Devin comment"      ;;
               esac
               ;;
             check_suite)
               case "$CHECK_CONCLUSION" in
-                success)   ICON=":white_check_mark:";   TITLE="Checks passed (${CHECK_APP})" ;;
-                failure)   ICON=":rotating_light:";     TITLE="Checks FAILED (${CHECK_APP})" ;;
-                cancelled) ICON=":no_entry:";           TITLE="Checks cancelled (${CHECK_APP})" ;;
-                neutral|skipped) ICON=":zzz:";          TITLE="Checks skipped (${CHECK_APP})" ;;
-                *)         ICON=":hourglass_flowing_sand:"; TITLE="Checks ${CHECK_CONCLUSION} (${CHECK_APP})" ;;
+                success)         ICON=":white_check_mark:";   TITLE="Checks passed (${CHECK_APP})" ;;
+                failure)         ICON=":rotating_light:";     TITLE="Checks FAILED (${CHECK_APP})" ;;
+                cancelled)       ICON=":no_entry:";           TITLE="Checks cancelled (${CHECK_APP})" ;;
+                neutral|skipped) ICON=":zzz:";                TITLE="Checks skipped (${CHECK_APP})" ;;
+                *)               ICON=":hourglass_flowing_sand:"; TITLE="Checks ${CHECK_CONCLUSION} (${CHECK_APP})" ;;
               esac
               ;;
             workflow_run)
@@ -149,7 +220,6 @@ jobs:
               ;;
           esac
 
-          # ── PR リンク行 ───────────────────────────────────────────────
           PR_LINE=""
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
             PR_LINE="<${PR_URL}|#${PR_NUMBER} ${PR_TITLE}>"
@@ -157,14 +227,12 @@ jobs:
             PR_LINE="<${WORKFLOW_URL}|workflow run>"
           fi
 
-          # ── レビュー本文 preview (400 文字 cap) ─────────────────────
           BODY_PREVIEW=""
           if [ -n "$REVIEW_BODY" ] && [ "$REVIEW_BODY" != "null" ]; then
-            # NULL bytes / 制御文字 / バックスラッシュは jq に渡す前に sanitize
             BODY_PREVIEW=$(printf '%s' "$REVIEW_BODY" | head -c 400)
           fi
 
-          # ── Slack payload を jq で安全にビルド ─────────────────────
+          # build base text + blocks (jq で injection 安全)
           PAYLOAD=$(jq -nc \
             --arg icon "$ICON" \
             --arg title "$TITLE" \
@@ -172,7 +240,9 @@ jobs:
             --arg body "$BODY_PREVIEW" \
             --arg url "$REVIEW_URL" \
             --arg repo "$REPO" \
+            --arg channel "$SLACK_CHANNEL_ID" \
             '{
+              channel: $channel,
               text: ($icon + " " + $title + (if $pr_line != "" then " · " + $pr_line else "" end)),
               blocks: (
                 [
@@ -201,19 +271,79 @@ jobs:
               )
             }')
 
-          # GITHUB_OUTPUT へ multiline を安全に書き出す
           delim="EOF_$(date +%s%N)"
           {
             echo "payload<<${delim}"
             printf '%s\n' "$PAYLOAD"
             echo "${delim}"
           } >> "$GITHUB_OUTPUT"
+          echo "is_parent=${IS_PARENT}" >> "$GITHUB_OUTPUT"
 
-      - name: Post to Slack
-        if: ${{ steps.filter.outputs.skip != 'true' && steps.payload.outputs.payload != '' }}
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: ${{ steps.payload.outputs.payload }}
+      # ── 親メッセージ post (PR opened/reopened/ready_for_review) ────────
+      # 既存 thread_ts marker が PR body に無い場合のみ実行。
+      - name: Post parent message and persist thread_ts
+        id: post_parent
+        if: |
+          steps.secrets_check.outputs.skip != 'true' &&
+          steps.filter.outputs.skip != 'true' &&
+          steps.payload.outputs.is_parent == 'true' &&
+          steps.ts.outputs.value == ''
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+          PAYLOAD: ${{ steps.payload.outputs.payload }}
+        run: |
+          set -e
+          RESP=$(curl -sS -X POST -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "${PAYLOAD}" \
+            https://slack.com/api/chat.postMessage)
+          OK=$(echo "$RESP" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            echo "::error::Slack chat.postMessage failed: $(echo "$RESP" | jq -r '.error // empty')"
+            echo "$RESP"
+            exit 1
+          fi
+          TS=$(echo "$RESP" | jq -r '.ts')
+          echo "Posted parent ts=$TS"
+
+          # PR body の末尾に marker を追記 (既存があれば update)
+          if [ -n "$PR_NUMBER" ]; then
+            BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+            if printf '%s' "$BODY" | grep -qE 'slack-thread-ts: [0-9]+\.[0-9]+'; then
+              printf '%s' "$BODY" | sed -E "s/slack-thread-ts: [0-9]+\.[0-9]+/slack-thread-ts: ${TS}/" > /tmp/pr-body.md
+            else
+              printf '%s\n\n<!-- slack-thread-ts: %s -->\n' "$BODY" "$TS" > /tmp/pr-body.md
+            fi
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file /tmp/pr-body.md
+          fi
+
+      # ── 親が既に存在: スレッド返信 / 親イベントだが marker なし: 親として post ──
+      - name: Post thread reply (or fallback)
+        if: |
+          steps.secrets_check.outputs.skip != 'true' &&
+          steps.filter.outputs.skip != 'true' &&
+          (
+            steps.payload.outputs.is_parent != 'true' ||
+            (steps.payload.outputs.is_parent == 'true' && steps.ts.outputs.value != '')
+          )
+        env:
+          PAYLOAD: ${{ steps.payload.outputs.payload }}
+          THREAD_TS: ${{ steps.ts.outputs.value }}
+        run: |
+          set -e
+          if [ -n "$THREAD_TS" ]; then
+            FINAL=$(printf '%s' "$PAYLOAD" | jq --arg ts "$THREAD_TS" '. + {thread_ts: $ts}')
+          else
+            FINAL="$PAYLOAD"
+          fi
+          RESP=$(curl -sS -X POST -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "${FINAL}" \
+            https://slack.com/api/chat.postMessage)
+          OK=$(echo "$RESP" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            echo "::error::Slack chat.postMessage failed: $(echo "$RESP" | jq -r '.error // empty')"
+            echo "$RESP"
+            exit 1
+          fi

--- a/.github/workflows/notify-pipeline.yml
+++ b/.github/workflows/notify-pipeline.yml
@@ -114,9 +114,9 @@ jobs:
             PR=$(echo "$WORKFLOW_RUN_PR" | jq -r '.[0].number // empty')
           fi
 
-          # フォールバック: head_sha から PR を逆引き
+          # フォールバック: head_sha から PR を逆引き (公式 API: list PRs associated with a commit)
           if [ -z "$PR" ] && [ -n "$HEAD_SHA" ] && [ "$HEAD_SHA" != "null" ]; then
-            PR=$(gh pr list --repo "$REPO" --state open --head-sha "$HEAD_SHA" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+            PR=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '[.[] | select(.state == "open")] | .[0].number // empty' 2>/dev/null || true)
           fi
 
           if [ -z "$PR" ]; then

--- a/.github/workflows/notify-pipeline.yml
+++ b/.github/workflows/notify-pipeline.yml
@@ -23,11 +23,13 @@ name: Notify pipeline events to Slack
 # Threading 仕組み:
 #   - PR opened/reopened/ready_for_review:
 #       chat.postMessage で post → 返り値の ts を取得
-#       → PR body 末尾に <!-- slack-thread-ts: NNN.MMM --> として書き込み
+#       → 専用 PR comment "<!-- slack-thread-ts: NNN.MMM -->" を upsert
+#         (PR body 直接編集は user の concurrent edit を clobber するため避ける)
 #   - その他のイベント:
-#       PR body から marker を読み出して thread_ts として指定
+#       PR comments から marker 付き comment を読み出して thread_ts として指定
 #       → スレッド返信として post
-#       (marker が無い fallback では flat に post)
+#   - PR を resolve できない event (push 経由 workflow_run / 非 PR check_suite)
+#     は skip し、flat な spam を Slack に出さない。
 
 on:
   pull_request:
@@ -44,7 +46,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write  # PR body に thread_ts marker を書き込むため
+  pull-requests: write  # marker 用 PR comment を作成・更新するため
+  issues: write         # PR comment は issues comments エンドポイント経由
 
 jobs:
   notify:
@@ -92,7 +95,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── PR 番号を event 別に解決 ────────────────────────────────────────
+      # ── PR 番号を event 別に解決。解決できなければ skip ─────────────────
       - name: Resolve PR number
         id: pr
         if: ${{ steps.secrets_check.outputs.skip != 'true' && steps.filter.outputs.skip != 'true' }}
@@ -120,37 +123,83 @@ jobs:
           fi
 
           if [ -z "$PR" ]; then
-            echo "::warning::Could not resolve PR number for event $EVENT_NAME; will post flat"
+            echo "::notice::No PR associated with $EVENT_NAME (e.g. push-triggered run); skipping notify"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "number=$PR" >> "$GITHUB_OUTPUT"
           fi
-          echo "number=$PR" >> "$GITHUB_OUTPUT"
 
-      # ── PR body から既存の thread_ts marker を読み出す ─────────────────
-      - name: Read thread_ts from PR body
+      # ── PR メタ (URL / title / merged) を取得 ───────────────────────────
+      # check_suite / workflow_run event では github.event.pull_request が無く
+      # PR_URL / PR_TITLE が空になるため、解決済み PR_NUMBER から API で補完。
+      - name: Fetch PR metadata
+        id: prmeta
+        if: |
+          steps.secrets_check.outputs.skip != 'true' &&
+          steps.filter.outputs.skip != 'true' &&
+          steps.pr.outputs.skip != 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+          EVENT_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
+          EVENT_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+          EVENT_MERGED: ${{ github.event.pull_request.merged }}
+        run: |
+          set -e
+          META=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '{html_url, title, merged}' 2>/dev/null || echo '{}')
+          URL=$(echo "$META" | jq -r '.html_url // empty')
+          TITLE=$(echo "$META" | jq -r '.title // empty')
+          MERGED=$(echo "$META" | jq -r '.merged // empty')
+          # API > event payload の優先順位 (event payload は PR の最新状態を反映している場合がある)
+          {
+            echo "url=${URL:-$EVENT_URL}"
+            echo "title=${TITLE:-$EVENT_TITLE}"
+            echo "merged=${MERGED:-$EVENT_MERGED}"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── 既存 thread_ts marker を専用 comment から読み出す ───────────────
+      # PR body を read-modify-write すると user の concurrent edit を上書きして
+      # しまうため、専用 PR comment (本 workflow が author=github-actions[bot])
+      # に marker を保存する。
+      - name: Read thread_ts marker comment
         id: ts
-        if: ${{ steps.secrets_check.outputs.skip != 'true' && steps.filter.outputs.skip != 'true' }}
+        if: |
+          steps.secrets_check.outputs.skip != 'true' &&
+          steps.filter.outputs.skip != 'true' &&
+          steps.pr.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
           set -e
           TS=""
-          if [ -n "$PR_NUMBER" ]; then
-            BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+          COMMENT_ID=""
+          # 直近 100 件から marker 付きコメントを find (anchor は parent post 直後に作るので最初期に存在)
+          MARKER=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq 'map(select(.body | test("<!-- slack-thread-ts:"))) | .[0] // empty' 2>/dev/null || echo "")
+          if [ -n "$MARKER" ] && [ "$MARKER" != "null" ]; then
+            COMMENT_ID=$(echo "$MARKER" | jq -r '.id // empty')
+            BODY=$(echo "$MARKER" | jq -r '.body // empty')
             TS=$(printf '%s' "$BODY" | grep -oE 'slack-thread-ts: [0-9]+\.[0-9]+' | head -1 | awk '{print $2}' || true)
           fi
           echo "value=$TS" >> "$GITHUB_OUTPUT"
+          echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
 
       # ── Slack payload を build ─────────────────────────────────────────
       - name: Build payload
         id: payload
-        if: ${{ steps.secrets_check.outputs.skip != 'true' && steps.filter.outputs.skip != 'true' }}
+        if: |
+          steps.secrets_check.outputs.skip != 'true' &&
+          steps.filter.outputs.skip != 'true' &&
+          steps.pr.outputs.skip != 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
-          PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
-          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_TITLE: ${{ steps.prmeta.outputs.title }}
+          PR_URL: ${{ steps.prmeta.outputs.url }}
+          PR_MERGED: ${{ steps.prmeta.outputs.merged }}
           REVIEW_USER: ${{ github.event.review.user.login || github.event.comment.user.login }}
           REVIEW_STATE: ${{ github.event.review.state }}
           REVIEW_BODY: ${{ github.event.review.body || github.event.comment.body }}
@@ -158,7 +207,6 @@ jobs:
           CHECK_APP: ${{ github.event.check_suite.app.name }}
           CHECK_CONCLUSION: ${{ github.event.check_suite.conclusion || github.event.workflow_run.conclusion }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
           REPO: ${{ github.repository }}
         run: |
           set -e
@@ -220,11 +268,12 @@ jobs:
               ;;
           esac
 
+          # PR_NUMBER は必ず解決済み (skip 経由で空にならない)
           PR_LINE=""
-          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+          if [ -n "$PR_URL" ]; then
             PR_LINE="<${PR_URL}|#${PR_NUMBER} ${PR_TITLE}>"
-          elif [ -n "$WORKFLOW_URL" ]; then
-            PR_LINE="<${WORKFLOW_URL}|workflow run>"
+          else
+            PR_LINE="#${PR_NUMBER} ${PR_TITLE}"
           fi
 
           BODY_PREVIEW=""
@@ -280,18 +329,21 @@ jobs:
           echo "is_parent=${IS_PARENT}" >> "$GITHUB_OUTPUT"
 
       # ── 親メッセージ post (PR opened/reopened/ready_for_review) ────────
-      # 既存 thread_ts marker が PR body に無い場合のみ実行。
-      - name: Post parent message and persist thread_ts
+      # 既存 marker comment が無い場合のみ実行。
+      # 取得した ts は **専用 PR comment** に upsert (PR body は触らない)。
+      - name: Post parent message and persist thread_ts marker comment
         id: post_parent
         if: |
           steps.secrets_check.outputs.skip != 'true' &&
           steps.filter.outputs.skip != 'true' &&
+          steps.pr.outputs.skip != 'true' &&
           steps.payload.outputs.is_parent == 'true' &&
           steps.ts.outputs.value == ''
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
           PAYLOAD: ${{ steps.payload.outputs.payload }}
+          EXISTING_COMMENT_ID: ${{ steps.ts.outputs.comment_id }}
         run: |
           set -e
           RESP=$(curl -sS -X POST -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
@@ -307,22 +359,22 @@ jobs:
           TS=$(echo "$RESP" | jq -r '.ts')
           echo "Posted parent ts=$TS"
 
-          # PR body の末尾に marker を追記 (既存があれば update)
-          if [ -n "$PR_NUMBER" ]; then
-            BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
-            if printf '%s' "$BODY" | grep -qE 'slack-thread-ts: [0-9]+\.[0-9]+'; then
-              printf '%s' "$BODY" | sed -E "s/slack-thread-ts: [0-9]+\.[0-9]+/slack-thread-ts: ${TS}/" > /tmp/pr-body.md
-            else
-              printf '%s\n\n<!-- slack-thread-ts: %s -->\n' "$BODY" "$TS" > /tmp/pr-body.md
-            fi
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file /tmp/pr-body.md
+          MARKER_BODY=$(printf '<!-- slack-thread-ts: %s -->\n\n_Slack thread anchor (auto-managed by `notify-pipeline.yml`). Do not edit._' "$TS")
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_COMMENT_ID" -f body="$MARKER_BODY" >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$MARKER_BODY" >/dev/null
           fi
 
       # ── 親が既に存在: スレッド返信 / 親イベントだが marker なし: 親として post ──
+      # PR は必ず resolve 済 (skip=true は前段で除外)。marker comment が無い
+      # 親イベント以外 (= 親が未 post の状態で review/check が来た) は flat
+      # post で fallback (post_parent は IS_PARENT==true でしか走らないため)。
       - name: Post thread reply (or fallback)
         if: |
           steps.secrets_check.outputs.skip != 'true' &&
           steps.filter.outputs.skip != 'true' &&
+          steps.pr.outputs.skip != 'true' &&
           (
             steps.payload.outputs.is_parent != 'true' ||
             (steps.payload.outputs.is_parent == 'true' && steps.ts.outputs.value != '')


### PR DESCRIPTION
## 概要

PR #92 で導入した Slack 通知を **同 PR の events を thread 返信としてまとめる** 仕様に変更。

### Before (PR #92)
- Slack に各 event が **flat に並ぶ** → channel が PR 通知で埋もれる
- Incoming Webhook ベース (ts が返らずスレッド化不可)

### After (この PR)
- PR opened が **親メッセージ**、以降の synchronize / review / check_suite / merge / close は **thread 返信**
- chat.postMessage API ベース (bot token 必須)

## 仕組み

```
PR opened:
  ├─ chat.postMessage → ts 取得
  ├─ PR body 末尾に <!-- slack-thread-ts: 1234567890.123456 --> を埋め込み
  └─ Slack に親メッセージとして表示

後続 (review / CI / merge):
  ├─ PR body から marker を読み出し ts 取得
  ├─ chat.postMessage with thread_ts=ts
  └─ スレッド返信として表示
```

## 必要な repo 設定

| Type | Name | Value | 状態 |
|---|---|---|---|
| Variable | `ENABLE_SLACK_NOTIFICATIONS` | `true` | ✅ 登録済 |
| Secret | `SLACK_BOT_TOKEN` | xoxb-... (Bot User OAuth Token) | ✅ 登録済 |
| Secret | `SLACK_CHANNEL_ID` | C0XXXXXXXX (通知先 channel ID) | ❌ **要登録** |

両 secret が揃わない repo では `Verify secrets` step で skip。設定漏れがあっても workflow は安全に no-op。

## Slack 側必要設定

1. Bot Token Scopes に `chat:write` + `chat:write.public` 追加
2. App reinstall (新 scope 承認)
3. 通知先 channel に bot を invite (private channel の場合: `/invite @<botname>`)

## permissions 変更

- `pull-requests: write` を追加 (PR body に thread_ts marker を書き込むため)

## 後始末

新 workflow では `SLACK_WEBHOOK_URL` は未使用。動作確認後に削除推奨:
```bash
gh secret delete SLACK_WEBHOOK_URL --repo mattyopon/faultray-app
```

## 動作確認方法

この PR が open された時点で workflow が走り、Slack の通知先 channel に :sparkles: 親メッセージが post される。CI / CodeRabbit / Vercel review 等の後続イベントが thread 返信として下に並ぶはず。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack notifications now support threaded replies with automatic parent message handling.

* **Bug Fixes**
  * Enhanced PR number resolution across all supported event types.
  * Added verification gate to gracefully skip execution when required Slack secrets are not configured.

* **Chores**
  * Updated Slack notification delivery mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->