### PR TITLE
fix(db): close schema-drift for contact_requests + coupons (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,14 @@ jobs:
           create or replace function auth.uid() returns uuid as $$
             select nullif(current_setting('request.jwt.claims', true)::jsonb->>'sub','')::uuid
           $$ language sql stable;
+          -- RLS policies on coupons (migration 016) も auth.role() を参照する。
+          -- Supabase 本番と同様、request.jwt.claims->>'role' を返す stub を提供。
+          create or replace function auth.role() returns text as $$
+            select coalesce(
+              nullif(current_setting('request.jwt.claims', true)::jsonb->>'role', ''),
+              'anon'
+            );
+          $$ language sql stable;
           -- test role placeholders (Supabase の実運用と同じ attribute)
           do $$ begin
             if not exists (select 1 from pg_roles where rolname = 'anon') then

--- a/src/app/api/coupon/redeem/route.ts
+++ b/src/app/api/coupon/redeem/route.ts
@@ -68,7 +68,11 @@ export async function POST(request: Request) {
 
   // 4. クーポンのcurrent_usesを楽観的ロックでインクリメント。
   // WHERE current_uses = coupon.current_uses で競合を検出。
-  const { data: updatedCoupons, error: incrementError } = await supabase
+  // admin client で実行: coupons の RLS は SELECT (authenticated) のみ許可、
+  // INSERT/UPDATE/DELETE policy 不在 → user client では RLS deny。migration 016
+  // で production faithful な policy 設計を再現したのに合わせ、increment は
+  // service_role bypass で行う (#72 / Codex review PR #100)。
+  const { data: updatedCoupons, error: incrementError } = await admin
     .from("coupons")
     .update({ current_uses: coupon.current_uses + 1 })
     .eq("id", coupon.id)

--- a/src/app/api/coupon/redeem/route.ts
+++ b/src/app/api/coupon/redeem/route.ts
@@ -111,7 +111,10 @@ export async function POST(request: Request) {
     // (review-loop 2 P1): rollback の affected row 数も見る。0 行なら別 worker
     // がこの間に increment しているため burn-without-credit 確定。
     console.error("[coupon/redeem] profile update failed:", profileError.message);
-    const { data: rolledBack, error: rollbackError } = await supabase
+    // rollback も admin client (service_role) で実行。migration 016 で coupons の
+    // UPDATE policy は不在 (RLS deny) のため user client では rollback も無効
+    // → 常に burn-without-credit に陥る (#72 PR #100 Codex review-loop 2 指摘)。
+    const { data: rolledBack, error: rollbackError } = await admin
       .from("coupons")
       .update({ current_uses: coupon.current_uses })
       .eq("id", coupon.id)

--- a/supabase/migrations/016_contact_requests_and_coupons.sql
+++ b/supabase/migrations/016_contact_requests_and_coupons.sql
@@ -1,0 +1,87 @@
+-- 016: schema-drift fix #72 — contact_requests + coupons
+-- ----------------------------------------------------------------------------
+-- 背景:
+--   PR #67 (#47) で production faultray-pro DDL を migrations に sync したが、
+--   `contact_requests` と `coupons` の 2 テーブルが漏れていた (Codex 4並列
+--   audit 2026-04-30 で検出 — issue #72)。
+--
+--   両テーブルとも production には存在し、アプリコードから参照されている:
+--     - contact_requests : src/app/contact/page.tsx (公開フォーム送信)
+--     - coupons          : src/app/api/coupon/redeem/route.ts (有料プラン引換)
+--
+--   migrations に欠落しているため fresh env (staging / local / preview deploy)
+--   でこれらの code path が 500 を返す。本マイグレーションは production の
+--   実 DDL (information_schema + pg_policies + pg_constraint + pg_indexes 経由
+--   で 2026-05-05 に Supabase Management API 抽出) を再現する。
+--
+-- Hardening についての注記:
+--   production の table-level grants は anon/authenticated/service_role に
+--   全 CRUD が付与されているが、これは Supabase の默认 grant 挙動
+--   (grant select, insert, update, delete on all tables in schema public to
+--   anon, authenticated) の副産物で、設計意図ではない。
+--   実際のアクセス制御は RLS policy で担保:
+--     - contact_requests : INSERT のみ任意 role 可、SELECT/UPDATE/DELETE は
+--                          policy 不在 → RLS deny (service_role bypass のみ)
+--     - coupons          : SELECT は authenticated のみ、INSERT/UPDATE/DELETE
+--                          は policy 不在 → RLS deny (service_role bypass のみ)
+--   grant 最小化と coupons.code への enumeration 対策 (rate-limit, secret code)
+--   は別 hardening issue で扱う。
+-- ----------------------------------------------------------------------------
+
+-- ── contact_requests: 公開問い合わせフォーム送信先 ──
+create table if not exists public.contact_requests (
+  id            uuid primary key default gen_random_uuid(),
+  company       text not null,
+  name          text not null,
+  email         text not null,
+  company_size  text not null,
+  message       text not null,
+  created_at    timestamptz not null default now()
+);
+
+alter table public.contact_requests enable row level security;
+
+-- 公開フォーム (anon client) からの INSERT を許可。
+-- SELECT/UPDATE/DELETE は policy 不在 → RLS deny (service_role bypass で運用)。
+drop policy if exists "Anyone can insert contact requests" on public.contact_requests;
+create policy "Anyone can insert contact requests"
+  on public.contact_requests
+  for insert
+  to public
+  with check (true);
+
+-- production faithful な grants (RLS で実アクセスを制限する前提)。
+grant select, insert, update, delete on public.contact_requests
+  to anon, authenticated;
+grant all on public.contact_requests to service_role;
+
+
+-- ── coupons: 有料プラン引換用クーポン ──
+create table if not exists public.coupons (
+  id             uuid primary key default gen_random_uuid(),
+  code           text not null unique,
+  tier           text not null default 'pro',
+  days           integer not null default 30,
+  max_uses       integer not null default 0,
+  current_uses   integer not null default 0,
+  note           text default '',
+  revoked        boolean not null default false,
+  created_at     timestamptz not null default now()
+);
+
+alter table public.coupons enable row level security;
+
+-- authenticated ユーザーのみ SELECT 可 (anon にコード列挙させない)。
+-- INSERT/UPDATE/DELETE policy は不在 → RLS deny。
+-- redeem (route.ts) は service_role client で current_uses をインクリメント。
+-- 手動発行は Supabase Studio (= service_role) で行う運用。
+drop policy if exists "Authenticated users can read coupons" on public.coupons;
+create policy "Authenticated users can read coupons"
+  on public.coupons
+  for select
+  to public
+  using (auth.role() = 'authenticated');
+
+grant select, insert, update, delete on public.coupons
+  to anon, authenticated;
+grant all on public.coupons to service_role;

--- a/supabase/tests/rls/multitenant.test.sql
+++ b/supabase/tests/rls/multitenant.test.sql
@@ -40,13 +40,16 @@ begin;
 create extension if not exists pgtap;
 
 -- ---------- テストプラン ----------
--- legacy 7 テーブル: 40 assertion (#28)
--- org/tasks 拡張    : 33 assertion (#73)
---   organizations  :  8  (SELECT × 6 + INSERT lives/throws × 2)
---   org_members    : 12  (SELECT × 6 + INSERT lives × 2 + INSERT throws × 4)
---   tasks          :  9  (SELECT × 6 + INSERT lives × 2 + TODO forgery × 1)
---   anon           :  4  (SELECT × 3 + INSERT throw × 1)
-select plan(73);
+-- legacy 7 テーブル        : 40 assertion (#28)
+-- org/tasks 拡張           : 33 assertion (#73)
+--   organizations          :  8  (SELECT × 6 + INSERT lives/throws × 2)
+--   org_members            : 12  (SELECT × 6 + INSERT lives × 2 + INSERT throws × 4)
+--   tasks                  :  9  (SELECT × 6 + INSERT lives × 2 + TODO forgery × 1)
+--   anon                   :  4  (SELECT × 3 + INSERT throw × 1)
+-- contact_requests/coupons :  7 assertion (#72)
+--   contact_requests       :  4  (anon INSERT lives + SELECT 0row, auth INSERT lives + SELECT 0row)
+--   coupons                :  3  (auth SELECT 1row, anon SELECT 0row, auth INSERT throws)
+select plan(80);
 
 -- ============================================================
 -- Setup: auth.users を直接 INSERT して 3 ユーザー + 2 team を作成
@@ -825,6 +828,76 @@ select throws_ok(
      values ('Anon org', '11111111-1111-1111-1111-111111111111'::uuid) $$,
   NULL::text, NULL::text,
   'anon: INSERT into organizations blocked'
+);
+
+-- ============================================================
+-- #72 contact_requests / coupons (schema-drift fix, migration 016)
+-- ============================================================
+-- production faithful な RLS 設計の regression-lock:
+--   contact_requests : INSERT は誰でも可、SELECT 等は policy 不在 → RLS deny
+--   coupons          : SELECT は authenticated のみ、INSERT 等は RLS deny
+
+-- ── contact_requests: anon が INSERT 可、SELECT 不可 ──
+select test_as_anon();
+
+select lives_ok(
+  $$ insert into public.contact_requests (company, name, email, company_size, message)
+     values ('Acme', 'Anon Sender', 'anon@test.local', '11-50', 'inquiry from public form') $$,
+  'contact_requests: anon CAN INSERT (public form path)'
+);
+
+select is(
+  (select count(*)::int from public.contact_requests),
+  0,
+  'contact_requests: anon SELECT returns 0 rows (no SELECT policy)'
+);
+
+-- ── contact_requests: authenticated も INSERT 可、SELECT 不可 ──
+select test_as_user(:'user_a_id'::uuid);
+
+select lives_ok(
+  $$ insert into public.contact_requests (company, name, email, company_size, message)
+     values ('Acme2', 'User A', 'a@test.local', '50-200', 'logged-in user inquiry') $$,
+  'contact_requests: authenticated CAN INSERT'
+);
+
+select is(
+  (select count(*)::int from public.contact_requests),
+  0,
+  'contact_requests: authenticated SELECT returns 0 rows (no SELECT policy)'
+);
+
+-- ── coupons: service_role でテスト用クーポン投入 (RLS bypass) ──
+select test_as_service_role();
+insert into public.coupons (code, tier, days, max_uses) values
+  ('TESTCODE72', 'pro', 30, 5);
+
+-- ── coupons: authenticated は SELECT 可 ──
+select test_as_user(:'user_a_id'::uuid);
+
+select is(
+  (select count(*)::int from public.coupons where code = 'TESTCODE72'),
+  1,
+  'coupons: authenticated CAN SELECT (auth.role()=authenticated policy matches)'
+);
+
+-- ── coupons: anon は SELECT 0 行 ──
+select test_as_anon();
+
+select is(
+  (select count(*)::int from public.coupons),
+  0,
+  'coupons: anon SELECT returns 0 rows (auth.role()!=authenticated)'
+);
+
+-- ── coupons: authenticated は INSERT block (INSERT policy 不在 → RLS deny) ──
+select test_as_user(:'user_a_id'::uuid);
+
+select throws_ok(
+  $$ insert into public.coupons (code, tier, days, max_uses)
+     values ('FORGED72', 'pro', 365, 0) $$,
+  NULL::text, NULL::text,
+  'coupons: authenticated CANNOT INSERT (no INSERT policy → RLS deny)'
 );
 
 -- ============================================================

--- a/supabase/tests/rls/multitenant.test.sql
+++ b/supabase/tests/rls/multitenant.test.sql
@@ -46,10 +46,10 @@ create extension if not exists pgtap;
 --   org_members            : 12  (SELECT × 6 + INSERT lives × 2 + INSERT throws × 4)
 --   tasks                  :  9  (SELECT × 6 + INSERT lives × 2 + TODO forgery × 1)
 --   anon                   :  4  (SELECT × 3 + INSERT throw × 1)
--- contact_requests/coupons :  7 assertion (#72)
+-- contact_requests/coupons :  8 assertion (#72)
 --   contact_requests       :  4  (anon INSERT lives + SELECT 0row, auth INSERT lives + SELECT 0row)
---   coupons                :  3  (auth SELECT 1row, anon SELECT 0row, auth INSERT throws)
-select plan(80);
+--   coupons                :  4  (auth SELECT 1row, anon SELECT 0row, auth INSERT throws, auth UPDATE 0 affected)
+select plan(81);
 
 -- ============================================================
 -- Setup: auth.users を直接 INSERT して 3 ユーザー + 2 team を作成
@@ -898,6 +898,22 @@ select throws_ok(
      values ('FORGED72', 'pro', 365, 0) $$,
   NULL::text, NULL::text,
   'coupons: authenticated CANNOT INSERT (no INSERT policy → RLS deny)'
+);
+
+-- ── coupons: authenticated は UPDATE silently denied (UPDATE policy 不在 → RLS deny) ──
+-- Postgres の RLS は UPDATE policy 不在の場合、視認できる行を更新しようとしても
+-- 0 affected (silent skip) になる (throws ではない)。これが /api/coupon/redeem を
+-- user client で increment しようとすると 409 に落ちる原因 (PR #100 Codex P1 review
+-- 指摘 → admin client へ修正)。本 assertion は redeem path の regression-lock:
+-- authenticated として UPDATE を試行し、service_role で current_uses が変更されて
+-- いないことを検証する。
+update public.coupons set current_uses = current_uses + 1 where code = 'TESTCODE72';
+
+select test_as_service_role();
+select is(
+  (select current_uses from public.coupons where code = 'TESTCODE72'),
+  0,
+  'coupons: authenticated UPDATE silently denied (current_uses unchanged after attempted increment)'
 );
 
 -- ============================================================


### PR DESCRIPTION
Closes #72.

## Summary

Production の `contact_requests` と `coupons` を `supabase/migrations/` に同期する。両テーブルは production faultray-pro に存在するが PR #67 (#47 schema-drift sync) で漏れていた 2 件で、fresh env (staging / local / preview deploy) ではこれらを参照する code path (`/contact` form, `/api/coupon/redeem`) が 500 を返す。

## Changes

### 1. `supabase/migrations/016_contact_requests_and_coupons.sql` (new)

production の DDL を **Supabase Management API** で 2026-05-05 に extract した結果を再現。

- columns: `information_schema.columns` で抽出。`id uuid pk default gen_random_uuid()`, text NOT NULL, `created_at timestamptz default now()`
- constraints: `pg_constraint` で抽出。`contact_requests_pkey`, `coupons_pkey`, `coupons_code_key` (UNIQUE)
- indexes: PK + UNIQUE のみ
- policies: `pg_policies` で抽出。contact_requests には INSERT policy のみ、coupons には auth.role()=authenticated で gate された SELECT policy のみ
- row count: 0 / 0 (両テーブルとも空)
- triggers: なし

### 2. `.github/workflows/ci.yml` の test-rls bootstrap に `auth.role()` stub を追加

migration 016 の coupons policy が `auth.role() = 'authenticated'` を参照する。CI の auth スタブには auth.uid() しかなかったため pgTAP 評価時に未定義関数エラーになる。`request.jwt.claims->>'role'` を返す stub を追加 (`test_as_user` / `test_as_anon` が claims に role を埋めているため、本番と同じ semantics)。

### 3. `supabase/tests/rls/multitenant.test.sql` に 7 assertions 追加 (`plan(73)` → `plan(80)`)

- contact_requests x 4: anon INSERT lives, anon SELECT 0row, authenticated INSERT lives, authenticated SELECT 0row
- coupons x 3: authenticated SELECT returns 1row (seeded via service_role bypass), anon SELECT 0row, authenticated INSERT throws (RLS deny)

## Production faithful vs hardening

本 migration は production faithful を優先。production の table-level GRANT は anon/authenticated/service_role 全 CRUD だが、Supabase の默认 grant 挙動の副産物で、実アクセス制御は RLS policy が担う。Grant minimization、coupons.code の enumeration 対策、CI schema-drift detection (#75) は別 hardening issue で扱う (本 PR の scope 外)。

## Verification

- DDL extract: Supabase Management API + jq で出力確認
- pgTAP local 実行: ローカル Postgres 不在のため CI 待ち
- 既存 pgTAP 73 件 -> 80 件 (+7) は CI test-rls job が緑になれば確証
