### PR TITLE
fix(stripe): customer_id source-of-truth, drop metadata.user_id trust (#79)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,14 +160,14 @@
         "filename": "src/app/api/stripe/webhook/route.ts",
         "hashed_secret": "6dc93fd5dfc39087aedf8cdc970dcd814aaffed9",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 165
       },
       {
         "type": "Secret Keyword",
         "filename": "src/app/api/stripe/webhook/route.ts",
         "hashed_secret": "e3ce06b48b5e21fad3402189e4ba16dfa5a481a1",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 167
       }
     ],
     "src/app/audit-log/page.tsx": [
@@ -478,5 +478,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-30T08:04:41Z"
+  "generated_at": "2026-05-06T11:33:36Z"
 }

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -154,25 +154,44 @@ export async function POST(request: Request) {
   // Stripe は repeat checkout のたびに新規 customer を作成 → webhook の bootstrap で
   // profiles.stripe_customer_id ≠ 新 customer になり customer_mismatch で plan 更新が
   // skip される (legitimate な resubscribe / upgrade flow が silent に壊れる)。
-  let existingCustomerId: string | null = null;
+  //
+  // (Codex review-loop 2 P1-B2): lookup 失敗を silent fall-through させると、課金は
+  // 通って plan 更新だけ落ちる "burn-without-credit" を再現してしまう。lookup が
+  // できない = customer reuse 判定ができない = checkout を進めるべきでない。503 で
+  // retry させ、ユーザーに明示的に再試行を促す。
   const supaUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supaServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (supaUrl && supaServiceKey) {
-    try {
-      const { createClient: createAdminClient } = await import("@supabase/supabase-js");
-      const adminSb = createAdminClient(supaUrl, supaServiceKey);
-      const { data: profile } = await adminSb
-        .from("profiles")
-        .select("stripe_customer_id")
-        .eq("id", userId)
-        .maybeSingle();
-      existingCustomerId = (profile?.stripe_customer_id as string | null) ?? null;
-    } catch (lookupErr) {
-      // service_role 経路の DB lookup が落ちても checkout は通したい (decay-friendly)。
-      // lookup 失敗 = 新規 customer 作成 → bootstrap で persist する path に fall back。
-      console.error("[stripe/checkout] profile lookup failed (continuing without customer reuse):",
-        lookupErr instanceof Error ? lookupErr.message : "unknown error");
+  if (!supaUrl || !supaServiceKey) {
+    console.error("[stripe/checkout] Supabase admin not configured — refusing checkout to avoid customer_mismatch drop");
+    return NextResponse.json(
+      { error: "Server configuration error. Please contact support." },
+      { status: 503 }
+    );
+  }
+  let existingCustomerId: string | null = null;
+  try {
+    const { createClient: createAdminClient } = await import("@supabase/supabase-js");
+    const adminSb = createAdminClient(supaUrl, supaServiceKey);
+    const { data: profile, error: lookupError } = await adminSb
+      .from("profiles")
+      .select("stripe_customer_id")
+      .eq("id", userId)
+      .maybeSingle();
+    if (lookupError) {
+      throw new Error(lookupError.message);
     }
+    existingCustomerId = (profile?.stripe_customer_id as string | null) ?? null;
+  } catch (lookupErr) {
+    // 503 で retry させる: silent fall-through (= 新規 customer 作成 → webhook
+    // bootstrap で customer_mismatch → 200 ack drop) を排除する。
+    console.error(
+      "[stripe/checkout] profile lookup failed — refusing checkout:",
+      lookupErr instanceof Error ? lookupErr.message : "unknown error"
+    );
+    return NextResponse.json(
+      { error: "Service temporarily unavailable. Please try again in a moment." },
+      { status: 503 }
+    );
   }
 
   try {

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -150,10 +150,37 @@ export async function POST(request: Request) {
   const hourBucket = Math.floor(Date.now() / 3600000);
   const idempotencyKey = `checkout-${userId}-${plan}-${interval}-${hourBucket}`;
 
+  // #79 PR #102 Codex P1-A: 既存 stripe_customer_id を再利用する。これを渡さないと
+  // Stripe は repeat checkout のたびに新規 customer を作成 → webhook の bootstrap で
+  // profiles.stripe_customer_id ≠ 新 customer になり customer_mismatch で plan 更新が
+  // skip される (legitimate な resubscribe / upgrade flow が silent に壊れる)。
+  let existingCustomerId: string | null = null;
+  const supaUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supaServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (supaUrl && supaServiceKey) {
+    try {
+      const { createClient: createAdminClient } = await import("@supabase/supabase-js");
+      const adminSb = createAdminClient(supaUrl, supaServiceKey);
+      const { data: profile } = await adminSb
+        .from("profiles")
+        .select("stripe_customer_id")
+        .eq("id", userId)
+        .maybeSingle();
+      existingCustomerId = (profile?.stripe_customer_id as string | null) ?? null;
+    } catch (lookupErr) {
+      // service_role 経路の DB lookup が落ちても checkout は通したい (decay-friendly)。
+      // lookup 失敗 = 新規 customer 作成 → bootstrap で persist する path に fall back。
+      console.error("[stripe/checkout] profile lookup failed (continuing without customer reuse):",
+        lookupErr instanceof Error ? lookupErr.message : "unknown error");
+    }
+  }
+
   try {
     const session = await stripe.checkout.sessions.create(
       {
         mode: "subscription",
+        // #79: 既存 customer を再利用 (repeat checkout で customer_mismatch を防ぐ)
+        ...(existingCustomerId ? { customer: existingCustomerId } : {}),
         // #21: Checkout URL共有リスク軽減 — セッションを30分で失効させる
         // Stripeのデフォルトは24時間。URLが共有・漏洩した場合のリスクを最小化する。
         expires_at: Math.floor(Date.now() / 1000) + 1800,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -453,13 +453,27 @@ export async function POST(request: Request) {
 
       // ── Subscription deleted: cancel or non-renewal ───────────────────────
       // #79 P1: customer_id source-of-truth で resolve。metadata.user_id は信用しない。
+      // (Codex review-loop 3 P2): /api/account/delete は profile を先に消してから
+      // Stripe subscriptions を cancel する設計のため、その flow の deleted event は
+      // profile が存在しない状態で到達する (= 通常 flow)。500 retry を 3 日間続ける
+      // のは ops noise なので、**deleted event のみ** profile not mapped を 200 ack
+      // で受容する。攻撃者目線では既に削除済 customer の deleted event を発火させても
+      // 何も起こせないため、リスクなし。
       case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription;
         const customerId = subscription.customer as string;
 
-        await updateUserByCustomerId(customerId, "free", "canceled");
+        const userId = await resolveUserByCustomerId(customerId);
+        if (!userId) {
+          console.info(
+            `[stripe/webhook] customer.subscription.deleted: customer=${customerId} ` +
+              `not mapped — likely account/delete flow, ack-ing without mutation.`
+          );
+          break;
+        }
+        await updateUserPlan(userId, "free", "canceled");
         console.info(
-          `[stripe/webhook] customer.subscription.deleted: customer=${customerId}`
+          `[stripe/webhook] customer.subscription.deleted: customer=${customerId} user=${userId}`
         );
         break;
       }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -67,22 +67,89 @@ async function updateUserPlan(userId: string, plan: PlanTier, subscriptionStatus
   }
 }
 
+// #79 P1: customer_id source-of-truth resolution.
+// metadata.user_id は forge 可能 (Stripe Checkout 作成時に攻撃者が任意設定可能)
+// なため、subscription / invoice 系の event では customerId → profiles の lookup
+// を唯一の真実源とする。bootstrap (checkout.session.completed) のみ metadata を
+// 使うが、cross-check で同じ userId に異なる customer が紐づくのを reject する。
+async function resolveUserByCustomerId(
+  customerId: string
+): Promise<string | null> {
+  const supabase = await getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("stripe_customer_id", customerId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Customer lookup failed: ${error.message}`);
+  }
+  return (data?.id as string | undefined) ?? null;
+}
+
 async function updateUserByCustomerId(
   customerId: string,
   plan: PlanTier,
   subscriptionStatus?: string
 ): Promise<void> {
-  const supabase = await getSupabaseAdmin();
-  const { data: profile, error: lookupError } = await supabase
-    .from("profiles")
-    .select("id")
-    .eq("stripe_customer_id", customerId)
-    .maybeSingle();
-  if (lookupError || !profile) {
-    console.warn(`[stripe/webhook] No profile found for customer ${customerId}`);
-    return;
+  const userId = await resolveUserByCustomerId(customerId);
+  if (!userId) {
+    // #81 (P2-3): silent warn + return は Stripe retry を停止させ event を永久消失
+    // させるため throw に変更。`profiles.stripe_customer_id` が未 bootstrap の
+    // ケースでは Stripe が retry → checkout.session.completed が先に処理されれば
+    // 次回 retry で resolve できる。永久 unmapped なら最終的に Stripe の retry
+    // 期限 (3日) で諦めるが、その間に operator が DB を確認して fix できる。
+    throw new Error(
+      `Customer not mapped to a profile (customer=${customerId}). ` +
+        `bootstrap (checkout.session.completed) で stripe_customer_id が未 persist。`
+    );
   }
-  await updateUserPlan(profile.id as string, plan, subscriptionStatus);
+  await updateUserPlan(userId, plan, subscriptionStatus);
+}
+
+// #79 P1: bootstrap path専用。`checkout.session.completed` で初めて customerId が
+// profile に紐づく時に呼ぶ。
+//   - profile が存在しない → profile_not_found (500 retry)
+//   - profile.stripe_customer_id が既存で event の customerId と異なる → customer_mismatch
+//     (attack indicator: 攻撃者が他人の userId を metadata.user_id に詰めた可能性)
+//   - profile.stripe_customer_id が NULL → 新規 persist
+//   - 一致 → no-op
+type BootstrapResult =
+  | { ok: true }
+  | { ok: false; reason: "profile_not_found" | "customer_mismatch" };
+
+async function bootstrapUserCustomer(
+  userId: string,
+  customerId: string
+): Promise<BootstrapResult> {
+  const supabase = await getSupabaseAdmin();
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("id, stripe_customer_id")
+    .eq("id", userId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Bootstrap profile lookup failed: ${error.message}`);
+  }
+  if (!profile) {
+    return { ok: false, reason: "profile_not_found" };
+  }
+  const existingCustomer = (profile.stripe_customer_id as string | null) ?? null;
+  if (existingCustomer && existingCustomer !== customerId) {
+    return { ok: false, reason: "customer_mismatch" };
+  }
+  if (existingCustomer === null) {
+    const { error: updateError } = await supabase
+      .from("profiles")
+      .update({ stripe_customer_id: customerId })
+      .eq("id", userId);
+    if (updateError) {
+      throw new Error(
+        `Failed to persist stripe_customer_id: ${updateError.message}`
+      );
+    }
+  }
+  return { ok: true };
 }
 
 export async function POST(request: Request) {
@@ -316,54 +383,84 @@ export async function POST(request: Request) {
   try {
     switch (event.type) {
       // ── Checkout completed: new subscription starts ──────────────────────
+      // #79 P1: 唯一 metadata.user_id を信用する bootstrap path。bootstrapUserCustomer
+      // で cross-check し、attack signature (customer_mismatch) は plan 変更を skip。
       case "checkout.session.completed": {
         const session = event.data.object as Stripe.Checkout.Session;
         const userId = session.metadata?.user_id;
         const plan = session.metadata?.plan as PlanTier | undefined;
+        const customerId =
+          typeof session.customer === "string" ? session.customer : null;
 
-        if (userId && plan && (plan === "starter" || plan === "pro" || plan === "business")) {
-          await updateUserPlan(userId, plan, "active");
-          console.info(`[stripe/webhook] checkout.session.completed: user=${userId} plan=${plan}`);
+        if (!userId || !plan || !customerId) {
+          console.warn(
+            `[stripe/webhook] checkout.session.completed: missing fields ` +
+              `(user_id=${userId ?? "null"} plan=${plan ?? "null"} customer=${customerId ?? "null"})`
+          );
+          break;
         }
+        if (plan !== "starter" && plan !== "pro" && plan !== "business") {
+          console.warn(
+            `[stripe/webhook] checkout.session.completed: invalid plan=${plan} (user=${userId})`
+          );
+          break;
+        }
+        const bootstrap = await bootstrapUserCustomer(userId, customerId);
+        if (!bootstrap.ok) {
+          if (bootstrap.reason === "customer_mismatch") {
+            // #79 attack signature: 既存 profile.stripe_customer_id と event の
+            // customerId が違う = 攻撃者が他人の user_id を metadata に詰めた可能性。
+            // 200 ack だけ返し、Stripe retry で同じ攻撃を増幅させない。
+            console.error(
+              `[stripe/webhook] checkout.session.completed: customer_mismatch ` +
+                `(user_id=${userId} got_customer=${customerId}). Possible metadata forgery — refusing to mutate plan.`
+            );
+            break;
+          }
+          // profile_not_found: race (auth.users → profiles trigger 未走) か
+          // metadata.user_id 偽装。500 で Stripe retry させる。
+          throw new Error(
+            `Bootstrap failed: ${bootstrap.reason} (user_id=${userId} customer=${customerId})`
+          );
+        }
+        await updateUserPlan(userId, plan, "active");
+        console.info(
+          `[stripe/webhook] checkout.session.completed: user=${userId} customer=${customerId} plan=${plan}`
+        );
         break;
       }
 
       // ── Subscription updated: plan change or renewal ─────────────────────
+      // #79 P1: customer_id source-of-truth で resolve。metadata.user_id は信用しない。
       case "customer.subscription.updated": {
         const subscription = event.data.object as Stripe.Subscription;
         const customerId = subscription.customer as string;
-        const userId = subscription.metadata?.user_id;
         const status = subscription.status; // active | past_due | canceled | ...
 
         // Determine plan from first price item
         const priceId = subscription.items.data[0]?.price?.id;
         const plan = priceId ? planTierFromPriceId(priceId) : null;
 
-        const resolvedPlan: PlanTier = (status === "active" || status === "trialing") && plan
-          ? plan
-          : "free";
+        const resolvedPlan: PlanTier =
+          (status === "active" || status === "trialing") && plan ? plan : "free";
 
-        if (userId) {
-          await updateUserPlan(userId, resolvedPlan, status);
-        } else {
-          await updateUserByCustomerId(customerId, resolvedPlan, status);
-        }
-        console.info(`[stripe/webhook] customer.subscription.updated: customer=${customerId} status=${status} plan=${resolvedPlan}`);
+        await updateUserByCustomerId(customerId, resolvedPlan, status);
+        console.info(
+          `[stripe/webhook] customer.subscription.updated: customer=${customerId} status=${status} plan=${resolvedPlan}`
+        );
         break;
       }
 
       // ── Subscription deleted: cancel or non-renewal ───────────────────────
+      // #79 P1: customer_id source-of-truth で resolve。metadata.user_id は信用しない。
       case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription;
         const customerId = subscription.customer as string;
-        const userId = subscription.metadata?.user_id;
 
-        if (userId) {
-          await updateUserPlan(userId, "free", "canceled");
-        } else {
-          await updateUserByCustomerId(customerId, "free", "canceled");
-        }
-        console.info(`[stripe/webhook] customer.subscription.deleted: customer=${customerId} user=${userId}`);
+        await updateUserByCustomerId(customerId, "free", "canceled");
+        console.info(
+          `[stripe/webhook] customer.subscription.deleted: customer=${customerId}`
+        );
         break;
       }
 
@@ -405,6 +502,7 @@ export async function POST(request: Request) {
       }
 
       // ── Payment succeeded: ensure status is active ───────────────────────
+      // #79 P1: customer_id source-of-truth で resolve。metadata.user_id は信用しない。
       case "invoice.payment_succeeded": {
         const invoice = event.data.object as Stripe.Invoice;
         const customerId = invoice.customer as string;
@@ -420,13 +518,10 @@ export async function POST(request: Request) {
           const priceId = subscription.items.data[0]?.price?.id;
           const plan = priceId ? planTierFromPriceId(priceId) : null;
           const resolvedPlan: PlanTier = plan ?? "pro";
-          const userId = subscription.metadata?.user_id;
-          if (userId) {
-            await updateUserPlan(userId, resolvedPlan, "active");
-          } else {
-            await updateUserByCustomerId(customerId, resolvedPlan, "active");
-          }
-          console.info(`[stripe/webhook] invoice.payment_succeeded: customer=${customerId} plan=${resolvedPlan}`);
+          await updateUserByCustomerId(customerId, resolvedPlan, "active");
+          console.info(
+            `[stripe/webhook] invoice.payment_succeeded: customer=${customerId} plan=${resolvedPlan}`
+          );
         }
         break;
       }


### PR DESCRIPTION
Closes #79 (P1 — Stripe webhook `metadata.user_id` 盲信) and #81 (P2-3 — customer not mapped silent 200).

## Attack surface (closed)

`subscription.metadata.user_id` / `session.metadata.user_id` は **任意の Stripe Checkout 作成者が制御可能**。Stripe signature verification は payload integrity を保証するだけで、metadata 値の真正性は保証しない。従来コードでは subscription / invoice 系の全 event が metadata.user_id をそのまま利用して `service_role` で profiles.plan を upgrade/cancel していた → **trivial cross-tenant compromise**。

本 PR 適用後:
- bootstrap (`checkout.session.completed`) のみ `metadata.user_id` を読み、`profiles.stripe_customer_id` と cross-check して `customer_mismatch` を 200 ack で reject
- それ以外の event は `customer_id` から `profiles` を join して resolve するのみ
- `customer not mapped` ケースは silent 200 → throw → 500 retry に変更 (#81)

## Changes

### 1. New helpers

- `resolveUserByCustomerId(customerId)`: 唯一の真実源 lookup。不在は `null`。
- `bootstrapUserCustomer(userId, customerId)`: checkout.session.completed 専用。
  - `profile_not_found` → 500 retry (race or forged userId)
  - `customer_mismatch` → 200 ack 無 mutate (attack signature, retry を増幅させない)
  - 一致 or NULL → persist + ok
- `updateUserByCustomerId(...)`: silent warn + return → throw に変更 (#81 fix)

### 2. Each case path 修正

| Event | Before | After |
|---|---|---|
| `checkout.session.completed` | `userId = metadata.user_id` 直信用 | `bootstrapUserCustomer(userId, customerId)` で cross-check |
| `customer.subscription.updated` | metadata 優先 + customer fallback | customer_id only |
| `customer.subscription.deleted` | 同上 | 同上 |
| `invoice.payment_succeeded` | metadata 優先 + customer fallback | customer_id only |
| `invoice.payment_failed` | customer_id only (silent warn) | customer_id only (throw → 500 retry) |

## Test 戦略

- TS / lint: ローカルで `tsc --noEmit` + `eslint` clean
- 既存 `tests/unit/stripe-webhook-no-any.test.ts` (`as any` regression) を維持 (本 PR で `as any` は新規導入していない)
- 新規 webhook logic test (bootstrap mismatch, resolve via customer_id 等) は **別 PR** で追加: 本 PR は P1 attack surface を最速で閉じることを優先。webhook signature verify と Supabase mock の重い setup は test-only PR で導入する

## Out of scope

- #82 P2-4: webhook last-write-wins / TOCTOU (別 PR、subscription `current_period_start` で stale event を弾く設計を別途検討)
- 新規 helper の vitest unit test (test-only PR で追加)
- production / staging の `profiles.stripe_customer_id` backfill (deploy/runbook 領域)
