### PR TITLE
fix(rls): tasks.assignee_id + member_systems cross-tenant guards (#80, #83)

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -82,6 +82,25 @@ export async function PATCH(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  // #80: assignee_id が cross-tenant でないことを app side で reject (DB 側の RLS
+  // WITH CHECK は migration 018 で hardening 済の double-defense)。NULL 化は許可、
+  // それ以外は task の existing.org_id に属する active member のみ。
+  if (body.assignee_id !== undefined && body.assignee_id !== null) {
+    const { data: assigneeMember, error: assigneeErr } = await supabase
+      .from("org_members")
+      .select("id")
+      .eq("id", body.assignee_id)
+      .eq("org_id", existing.org_id)
+      .eq("status", "active")
+      .maybeSingle();
+    if (assigneeErr || !assigneeMember) {
+      return NextResponse.json(
+        { error: "assignee_id must be an active member of the same organization" },
+        { status: 400 }
+      );
+    }
+  }
+
   // 更新フィールドを構築
   const updatePayload: Record<string, unknown> = {
     updated_at: new Date().toISOString(),

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -109,6 +109,24 @@ export async function POST(request: Request) {
     );
   }
 
+  // #80: assignee_id が cross-tenant でないことを app side で reject (DB 側の RLS
+  // WITH CHECK は migration 018 で hardening 済の double-defense)。
+  if (assignee_id) {
+    const { data: assigneeMember, error: assigneeErr } = await supabase
+      .from("org_members")
+      .select("id")
+      .eq("id", assignee_id)
+      .eq("org_id", orgId)
+      .eq("status", "active")
+      .maybeSingle();
+    if (assigneeErr || !assigneeMember) {
+      return NextResponse.json(
+        { error: "assignee_id must be an active member of the same organization" },
+        { status: 400 }
+      );
+    }
+  }
+
   const insertPayload: Record<string, unknown> = {
     org_id: orgId,
     title: title.trim(),

--- a/supabase/migrations/018_tasks_member_systems_cross_tenant_guards.sql
+++ b/supabase/migrations/018_tasks_member_systems_cross_tenant_guards.sql
@@ -1,0 +1,107 @@
+-- 018: #80 + #83 — cross-tenant data integrity guards
+-- ----------------------------------------------------------------------------
+-- #80 (tasks.assignee_id cross-tenant): tasks INSERT/UPDATE で attacker が
+--      他 org の `org_members.id` を assignee に詰める可能性。RLS USING で row
+--      自体は隔離されるが、新規 row に他 org の reference が紛れ込むのは
+--      下流 UI/通知/分析で leak の温床になる。WITH CHECK で assignee_id が
+--      同 org_id の active member に属することを強制する。
+--      app side (api/tasks routes) でも先に reject する double-defense。
+--
+-- #83 (member_systems cross-company): migration 004 の `Company owner can
+--      insert/update member_systems` policies は member_id の所属 company を
+--      確認するが system_id は無検査。同じ company owner であれば自社 member
+--      の row を作れるが、system_id に他社の system を指定可能。
+--      WITH CHECK に system_id 側の company match 条件を追加する。
+-- ----------------------------------------------------------------------------
+
+-- ── 1. tasks: assignee_id 同 org check + UPDATE WITH CHECK 追加 ──
+-- 015 で導入済の SELECT/UPDATE/DELETE/INSERT policies のうち、INSERT と
+-- UPDATE を WITH CHECK 強化する。SELECT/DELETE はそのまま。
+
+drop policy if exists "Org members can insert tasks" on public.tasks;
+drop policy if exists "Org members can update tasks" on public.tasks;
+
+-- INSERT: 015 の created_by + org_id check に assignee_id same-org guard を追加
+create policy "Org members can insert tasks"
+  on public.tasks for insert
+  with check (
+    created_by = auth.uid()
+    and org_id in (select public.user_org_ids())
+    and (
+      assignee_id is null
+      or exists (
+        select 1 from public.org_members om
+        where om.id = assignee_id
+          and om.org_id = public.tasks.org_id
+          and om.status = 'active'
+      )
+    )
+  );
+
+-- UPDATE: 元 USING のみ → WITH CHECK で post-update 値も同 RLS scope を強制
+-- (cross-tenant 移動防止 + assignee_id same-org 維持)
+create policy "Org members can update tasks"
+  on public.tasks for update
+  using (org_id in (select public.user_org_ids()))
+  with check (
+    org_id in (select public.user_org_ids())
+    and (
+      assignee_id is null
+      or exists (
+        select 1 from public.org_members om
+        where om.id = assignee_id
+          and om.org_id = public.tasks.org_id
+          and om.status = 'active'
+      )
+    )
+  );
+
+
+-- ── 2. member_systems: INSERT/UPDATE policy を再作成し system_id 側の同 company を強制 ──
+-- production では migration 004 の "Company owner can ..." policies が現在不在で
+-- "Allow read access" の SELECT のみ存在 (drift)。fresh env では 004 で作られる
+-- ため、IF EXISTS で安全に DROP → CREATE する。
+-- どちらの env でも同一の最終状態 (member.company_id = system.company_id 強制
+-- された INSERT/UPDATE policy) に揃える。
+
+drop policy if exists "Company owner can insert member_systems"
+  on public.member_systems;
+drop policy if exists "Company owner can update member_systems"
+  on public.member_systems;
+
+create policy "Company owner can insert member_systems"
+  on public.member_systems for insert
+  with check (
+    exists (
+      select 1
+      from public.members m
+      join public.companies c on c.id = m.company_id
+      join public.systems s on s.company_id = c.id
+      where m.id = member_systems.member_id
+        and s.id = member_systems.system_id
+        and c.owner_id = auth.uid()
+    )
+  );
+
+create policy "Company owner can update member_systems"
+  on public.member_systems for update
+  using (
+    exists (
+      select 1
+      from public.members m
+      join public.companies c on c.id = m.company_id
+      where m.id = member_systems.member_id
+        and c.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.members m
+      join public.companies c on c.id = m.company_id
+      join public.systems s on s.company_id = c.id
+      where m.id = member_systems.member_id
+        and s.id = member_systems.system_id
+        and c.owner_id = auth.uid()
+    )
+  );

--- a/supabase/tests/rls/multitenant.test.sql
+++ b/supabase/tests/rls/multitenant.test.sql
@@ -49,9 +49,12 @@ create extension if not exists pgtap;
 -- contact_requests/coupons :  8 assertion (#72)
 --   contact_requests       :  4  (anon INSERT lives + SELECT 0row, auth INSERT lives + SELECT 0row)
 --   coupons                :  4  (auth SELECT 1row, anon SELECT 0row, auth INSERT throws, auth UPDATE 0 affected)
+-- tasks.assignee_id guard  :  4 assertion (#80, migration 018)
+--   INSERT same-org lives + cross-org throws + NULL lives + UPDATE cross-org throws
+-- member_systems WITH CHECK:  2 assertion (#83, migration 018, structural existence)
 -- delete_user_account RPC  :  6 assertion (#70 finding 3-5, migration 017)
 --   pre/post check         :  6  (org_p delete via owner CASCADE + cascade chain, org_q untouched)
-select plan(87);
+select plan(93);
 
 -- ============================================================
 -- Setup: auth.users を直接 INSERT して 3 ユーザー + 2 team を作成
@@ -69,6 +72,10 @@ select plan(87);
 \set org_q_id   'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
 \set task_p_id  'cccccccc-cccc-cccc-cccc-cccccccccccc'
 \set task_q_id  'dddddddd-dddd-dddd-dddd-dddddddddddd'
+-- #80 org_members.id を固定 (assignee_id same-org guard test 用)
+\set om_a_p_id  'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+\set om_b_p_id  'ffffffff-ffff-ffff-ffff-ffffffffffff'
+\set om_c_q_id  '00000000-1111-2222-3333-444444444444'
 
 -- auth.users (最小フィールド)
 insert into auth.users (id, email, raw_user_meta_data, aud, role)
@@ -149,10 +156,10 @@ insert into public.organizations (id, name, owner_id) values
   (:'org_p_id'::uuid, 'Org P', :'user_a_id'::uuid),
   (:'org_q_id'::uuid, 'Org Q', :'user_c_id'::uuid);
 
-insert into public.org_members (org_id, user_id, email, role, status) values
-  (:'org_p_id'::uuid, :'user_a_id'::uuid, 'a@test.local', 'admin',  'active'),
-  (:'org_p_id'::uuid, :'user_b_id'::uuid, 'b@test.local', 'member', 'active'),
-  (:'org_q_id'::uuid, :'user_c_id'::uuid, 'c@test.local', 'owner',  'active');
+insert into public.org_members (id, org_id, user_id, email, role, status) values
+  (:'om_a_p_id'::uuid, :'org_p_id'::uuid, :'user_a_id'::uuid, 'a@test.local', 'admin',  'active'),
+  (:'om_b_p_id'::uuid, :'org_p_id'::uuid, :'user_b_id'::uuid, 'b@test.local', 'member', 'active'),
+  (:'om_c_q_id'::uuid, :'org_q_id'::uuid, :'user_c_id'::uuid, 'c@test.local', 'owner',  'active');
 
 -- tasks: 1 per org (assignee_id は省略 → null)
 insert into public.tasks (id, org_id, title, created_by) values
@@ -916,6 +923,81 @@ select is(
   (select current_uses from public.coupons where code = 'TESTCODE72'),
   0,
   'coupons: authenticated UPDATE silently denied (current_uses unchanged after attempted increment)'
+);
+
+-- ============================================================
+-- #80: tasks.assignee_id same-org WITH CHECK guard (migration 018)
+-- ============================================================
+-- user_a (admin of org_p) として 4 ケース:
+--   (a) same-org assignee (om_b_p_id) → allowed
+--   (b) cross-org assignee (om_c_q_id) → blocked by WITH CHECK
+--   (c) NULL assignee → allowed
+--   (d) UPDATE existing task assignee to cross-org → blocked by WITH CHECK
+
+select test_as_user(:'user_a_id'::uuid);
+
+select lives_ok(
+  format(
+    $sql$ insert into public.tasks (org_id, title, created_by, assignee_id)
+          values (%L::uuid, '%s', %L::uuid, %L::uuid) $sql$,
+    :'org_p_id', 'task with same-org assignee', :'user_a_id', :'om_b_p_id'
+  ),
+  '#80: INSERT task with same-org assignee_id (B in org_p) — allowed'
+);
+
+select throws_ok(
+  format(
+    $sql$ insert into public.tasks (org_id, title, created_by, assignee_id)
+          values (%L::uuid, '%s', %L::uuid, %L::uuid) $sql$,
+    :'org_p_id', 'task with cross-org assignee', :'user_a_id', :'om_c_q_id'
+  ),
+  NULL::text, NULL::text,
+  '#80: INSERT task with cross-org assignee_id (C in org_q) — blocked'
+);
+
+select lives_ok(
+  format(
+    $sql$ insert into public.tasks (org_id, title, created_by, assignee_id)
+          values (%L::uuid, '%s', %L::uuid, NULL) $sql$,
+    :'org_p_id', 'task with NULL assignee', :'user_a_id'
+  ),
+  '#80: INSERT task with NULL assignee_id — allowed'
+);
+
+select throws_ok(
+  format(
+    $sql$ update public.tasks set assignee_id = %L::uuid where id = %L::uuid $sql$,
+    :'om_c_q_id', :'task_p_id'
+  ),
+  NULL::text, NULL::text,
+  '#80: UPDATE task assignee_id to cross-org member — blocked'
+);
+
+-- ============================================================
+-- #83: member_systems WITH CHECK 構造的存在 (migration 018)
+-- ============================================================
+-- member_systems / members / companies / systems の完全 SEED は scope 拡大に
+-- なるため、本 PR では migration 018 が「INSERT/UPDATE policy を WITH CHECK
+-- 付きで作成した」ことを構造的に確認する (DB drift 検出として十分)。
+
+select test_as_service_role();
+
+select isnt(
+  (select with_check from pg_policies
+    where schemaname = 'public'
+      and tablename = 'member_systems'
+      and policyname = 'Company owner can insert member_systems'),
+  NULL,
+  '#83: member_systems INSERT policy exists with WITH CHECK (cross-company guard)'
+);
+
+select isnt(
+  (select with_check from pg_policies
+    where schemaname = 'public'
+      and tablename = 'member_systems'
+      and policyname = 'Company owner can update member_systems'),
+  NULL,
+  '#83: member_systems UPDATE policy exists with WITH CHECK (cross-company guard)'
 );
 
 -- ============================================================


### PR DESCRIPTION
Closes #80 + #83.

## #80 — tasks.assignee_id cross-tenant

- migration 018: `tasks` INSERT/UPDATE policies に WITH CHECK 追加で `assignee_id IS NULL OR exists(active member of same org_id)` を強制
- `src/app/api/tasks/route.ts` POST + `src/app/api/tasks/[id]/route.ts` PATCH に app-level lookup を追加 (400 早期 reject)
- pgTAP +4: same-org lives / cross-org throws / NULL lives / UPDATE cross-org throws

## #83 — member_systems cross-company

- migration 018: `Company owner can insert/update member_systems` policies を再作成し、WITH CHECK で `members.company_id = systems.company_id = c.owner_id=auth.uid()` を強制 (system_id forgery 閉鎖)
- pgTAP +2: WITH CHECK 構造的存在 (behavioral test は members/companies/systems の完全 SEED が要 → scope 外)

## SEED

- org_members 行に `om_a_p_id` / `om_b_p_id` / `om_c_q_id` の固定 id を付与 (#80 test で direct reference)
- plan(87) → plan(93)

## Verification

- tsc clean / eslint clean
- migration 適用順: 015 (org_members SECURITY DEFINER) → 016/017 → 018 (本 PR) で drift なし
- production schema は別 deploy pipeline (#75 ops bundle で CI drift detection 検討中)
