### PR TITLE
chore(deps): runtime bumps — react 19.2.6, react-dom 19.2.6, @supabase/ssr 0.10.3, stripe 22.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "faultray-app",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/ssr": "^0.10.2",
+        "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.4",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
         "next": "^16.2.6",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "server-only": "^0.0.1",
-        "stripe": "^22.0.0",
+        "stripe": "^22.1.1",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -1866,15 +1866,15 @@
       }
     },
     "node_modules/@supabase/ssr": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
-      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.3.tgz",
+      "integrity": "sha512-ux2CJgX89h0Fz2lY7ZNafNG2SkXpyRc5dz77K9eKeBLPdtywQixKwIuetDeIViAJBp/buOUVmgj8PVesOklNpw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.2"
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.102.1"
+        "@supabase/supabase-js": "^2.105.3"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -4778,6 +4778,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6829,24 +6830,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -7538,9 +7539,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.0.0.tgz",
-      "integrity": "sha512-q1UgXXpSfZCmkyzZEh3vFEWT7+ajuaFGqaP9Tsi2NMtwlkigIWNr+KBIUQqtNeNEsreDKgdn+BP5HRW9JDj22Q==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
     "quality": "npm run lint && npm run test"
   },
   "dependencies": {
-    "@supabase/ssr": "^0.10.2",
+    "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.4",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
     "next": "^16.2.6",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "server-only": "^0.0.1",
-    "stripe": "^22.0.0",
+    "stripe": "^22.1.1",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Applies the four pending **runtime** dependabot bumps in one commit (single CI cycle, no serial lockfile-rebase conflicts):

- react `19.2.5 → 19.2.6` (#129)
- react-dom `19.2.5 → 19.2.6` (#130)
- @supabase/ssr `0.10.2 → 0.10.3` (#128)
- stripe `22.0.0 → 22.1.1` (#108)

package.json ranges match the dependabot PRs exactly, so dependabot will auto-close #129/#130/#128/#108 once this reaches main.

The dev-dependencies group (#127) is intentionally **not** included — it contains three majors (typescript 6, eslint 10, @types/node 25) and follows separately after local verification.

Verified locally: `tsc --noEmit` clean, `eslint .` clean, Vitest 249/249, production build OK.

https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A

---
_Generated by [Claude Code](https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A)_