### PR TITLE
fix: Codex-audit correctness bugs — CSRF fail-closed, trial-reminder population, deterministic org selection, task error handling

### DIFF
--- a/src/app/api/cron/trial-reminders/route.ts
+++ b/src/app/api/cron/trial-reminders/route.ts
@@ -34,12 +34,18 @@ export async function POST(request: Request) {
   const threeDaysLater = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
   const fourDaysLater = new Date(now.getTime() + 4 * 24 * 60 * 60 * 1000);
 
+  // #115: trial users carry a paid plan ('business' from the auth-callback
+  // provisioning, or 'pro' from a coupon) plus trial_ends_at — NOT plan='free'.
+  // Filtering plan='free' selected the empty/wrong set, so reminders never
+  // reached the people about to expire. The real signal for "still trialing,
+  // not yet converted" is: a trial_ends_at in the window AND no Stripe customer
+  // (a converted customer has stripe_customer_id set after checkout).
   const { data: users, error: queryError } = await supabase
     .from("profiles")
     .select("id, email, full_name, trial_ends_at")
     .gte("trial_ends_at", threeDaysLater.toISOString())
     .lt("trial_ends_at", fourDaysLater.toISOString())
-    .eq("plan", "free");
+    .is("stripe_customer_id", null);
 
   if (queryError) {
     console.error("[cron/trial-reminders] Query error:", queryError.message);

--- a/src/app/api/org/members/route.ts
+++ b/src/app/api/org/members/route.ts
@@ -28,13 +28,15 @@ export async function GET(request: Request) {
     .from("org_members")
     .select("org_id")
     .eq("user_id", user.id)
-    .eq("status", "active");
+    .eq("status", "active")
+    .order("invited_at", { ascending: true });
 
   // ownerとして作成した組織も含める
   const { data: ownedOrgs } = await supabase
     .from("organizations")
     .select("id")
-    .eq("owner_id", user.id);
+    .eq("owner_id", user.id)
+    .order("created_at", { ascending: true });
 
   const orgIds = Array.from(
     new Set([

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -53,13 +53,19 @@ export async function PATCH(
     }
   }
 
-  // タスクが自分の組織のものか確認
-  const { data: existing } = await supabase
+  // タスクが自分の組織のものか確認。#122: real な query error と「行なし」を
+  // 区別する。maybeSingle は 0 行で {data:null, error:null} を返すので、error は
+  // DB 障害時のみ立つ。これを 404 に潰すと outage が「タスク無し」に偽装され、
+  // 監視・自動リトライが効かなくなる。
+  const { data: existing, error: existingError } = await supabase
     .from("tasks")
     .select("id, org_id")
     .eq("id", id)
-    .single();
+    .maybeSingle();
 
+  if (existingError) {
+    return NextResponse.json({ error: "Failed to look up task" }, { status: 500 });
+  }
   if (!existing) {
     return NextResponse.json({ error: "Task not found" }, { status: 404 });
   }
@@ -143,13 +149,19 @@ export async function DELETE(
 
   const { id } = await params;
 
-  // タスクが自分の組織のものか確認
-  const { data: existing } = await supabase
+  // タスクが自分の組織のものか確認。#122: real な query error と「行なし」を
+  // 区別する。maybeSingle は 0 行で {data:null, error:null} を返すので、error は
+  // DB 障害時のみ立つ。これを 404 に潰すと outage が「タスク無し」に偽装され、
+  // 監視・自動リトライが効かなくなる。
+  const { data: existing, error: existingError } = await supabase
     .from("tasks")
     .select("id, org_id")
     .eq("id", id)
-    .single();
+    .maybeSingle();
 
+  if (existingError) {
+    return NextResponse.json({ error: "Failed to look up task" }, { status: 500 });
+  }
   if (!existing) {
     return NextResponse.json({ error: "Task not found" }, { status: 404 });
   }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -25,6 +25,7 @@ async function getOrgId(
     .select("org_id")
     .eq("user_id", userId)
     .eq("status", "active")
+    .order("invited_at", { ascending: true })
     .limit(1);
 
   if (memberships && memberships.length > 0) {
@@ -35,6 +36,7 @@ async function getOrgId(
     .from("organizations")
     .select("id")
     .eq("owner_id", userId)
+    .order("created_at", { ascending: true })
     .limit(1);
 
   if (ownedOrgs && ownedOrgs.length > 0) {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -98,9 +98,19 @@ function checkCsrf(request: Request): NextResponse | null {
   }
 
   if (allowed.size === 0) {
-    // 設定 mis でいかなる allowlist も組み立てられない → fail-open
-    // (production で NEXT_PUBLIC_SITE_URL が malformed だと全 request 403 に
-    //  なるのを避ける従来挙動を維持)
+    // #113: no valid origin could be derived (every configured origin missing
+    // or malformed). Fail CLOSED in production — returning null drops Origin
+    // enforcement on every state-changing route (account delete, coupon redeem,
+    // org/task mutations), so an env typo would silently reopen CSRF. A
+    // misconfiguration that 403s is loud and recoverable; a silent bypass is
+    // not. Dev/preview keep the permissive path so local work and ephemeral
+    // preview URLs aren't blocked.
+    if (isProduction) {
+      return NextResponse.json(
+        { error: "Forbidden: CSRF origin allowlist unavailable" },
+        { status: 403 }
+      );
+    }
     return null;
   }
 

--- a/tests/unit/issue-fixes-codex-audit.test.ts
+++ b/tests/unit/issue-fixes-codex-audit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * L2 Regression: Codex-audit correctness fixes (#113, #115, #120, #121, #122).
+ *
+ * These are source-scan assertions in the same style as the audit-log and
+ * stripe-webhook regression tests: they pin the corrected shape so a later
+ * edit can't silently revert it, without standing up a Supabase mock.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SRC = resolve(__dirname, "../..");
+const read = (p: string) => readFileSync(resolve(SRC, p), "utf-8");
+
+describe("#113: CSRF guard fails closed in production", () => {
+  const src = read("src/lib/api-auth.ts");
+
+  it("returns 403 from the empty-allowlist branch when in production", () => {
+    // The empty-allowlist block must gate on isProduction and 403, not just
+    // `return null` unconditionally.
+    const block = src.match(/if \(allowed\.size === 0\)\s*\{[\s\S]*?\n  \}/);
+    expect(block, "allowed.size === 0 block not found").toBeTruthy();
+    expect(block![0]).toMatch(/isProduction/);
+    expect(block![0]).toMatch(/status:\s*403/);
+  });
+
+  it("does not unconditionally fail open on an empty allowlist", () => {
+    // Guard against regressing to a bare `return null` as the only action.
+    const block = src.match(/if \(allowed\.size === 0\)\s*\{[\s\S]*?\n  \}/)![0];
+    const lines = block.split("\n").map((l) => l.trim());
+    const idx = lines.findIndex((l) => l.startsWith("if (allowed.size === 0)"));
+    // The statement immediately inside the block must not be `return null;`.
+    expect(lines[idx + 1]).not.toBe("return null;");
+  });
+});
+
+describe("#115: trial-reminders targets unconverted trialers, not plan=free", () => {
+  const src = read("src/app/api/cron/trial-reminders/route.ts");
+
+  it("filters on a null stripe_customer_id", () => {
+    expect(src).toMatch(/\.is\(\s*["']stripe_customer_id["']\s*,\s*null\s*\)/);
+  });
+
+  it("no longer filters the population by plan='free'", () => {
+    expect(src).not.toMatch(/\.eq\(\s*["']plan["']\s*,\s*["']free["']\s*\)/);
+  });
+});
+
+describe("#120/#121: deterministic org selection", () => {
+  it("org/members orders both membership and ownership queries", () => {
+    const src = read("src/app/api/org/members/route.ts");
+    expect(src).toMatch(/\.order\(\s*["']invited_at["']/);
+    expect(src).toMatch(/\.order\(\s*["']created_at["']/);
+  });
+
+  it("tasks getOrgId orders both membership and ownership queries", () => {
+    const src = read("src/app/api/tasks/route.ts");
+    expect(src).toMatch(/\.order\(\s*["']invited_at["']/);
+    expect(src).toMatch(/\.order\(\s*["']created_at["']/);
+  });
+});
+
+describe("#122: tasks/[id] distinguishes query failure from missing row", () => {
+  const src = read("src/app/api/tasks/[id]/route.ts");
+
+  it("uses maybeSingle for the existence lookup and surfaces DB errors as 500", () => {
+    expect(src).toMatch(/existingError/);
+    // The 500 branch text appears once per handler (PATCH + DELETE).
+    const matches = src.match(/Failed to look up task/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it("existence lookup no longer uses .single() (which 404s on any error)", () => {
+    // The existence query selects "id, org_id"; assert that specific query
+    // resolves via maybeSingle, not single.
+    expect(src).toMatch(/\.select\("id, org_id"\)[\s\S]*?\.maybeSingle\(\)/);
+  });
+});


### PR DESCRIPTION
Fixes five Codex-audit correctness issues. All are contained, code-only changes with source-scan regression tests; no schema/infra/product-behavior changes.

| Issue | Bug | Fix |
|---|---|---|
| **#113** security-csrf | When no valid origin could be derived, `checkCsrf` returned `null` (no enforcement) — an env typo silently reopened CSRF on every state-changing route. | Fail **closed** (403) in production; dev/preview keep the permissive path so local + ephemeral preview URLs work. |
| **#115** quality-bug | trial-reminders filtered `plan='free'`, but trial users carry a paid plan (`business` from auth-callback, `pro` from coupon) + `trial_ends_at` — so the reminder population was empty/wrong. | Select by the `trial_ends_at` window **and** a null `stripe_customer_id` (still trialing, not yet converted). |
| **#120** security-idor | org/members used `orgIds[0]` from **unordered** queries → a multi-org user could get a different tenant per request. | Order both the membership (`invited_at`) and ownership (`created_at`) queries. |
| **#121** security-idor | Same non-determinism in `getOrgId` for the tasks endpoint. | Same deterministic ordering on both lookups. |
| **#122** quality-error-handling | tasks/[id] PATCH+DELETE used `.single()` and treated **any** error as "Task not found" (404), masking DB outages. | `maybeSingle()` + explicit **500** on a real query error; 404 reserved for genuine missing rows. |

Regression tests: `tests/unit/issue-fixes-codex-audit.test.ts` (8 assertions) pin each corrected shape.

Verified locally: `tsc --noEmit` clean, `eslint` clean on changed files, Vitest **257/257** (249 + 8 new).

### Note on #115 interaction with #114
#114 (new users never get a trial provisioned, because the `handle_new_user` trigger already creates the profile row) means `trial_ends_at` is rarely set today, so #115's practical blast radius is small until #114 is resolved. #114 is left open — it changes outward-facing onboarding/billing and is best fixed at the trigger with a real Supabase to verify.

Closes #113, #115, #120, #121, #122

https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A

---
_Generated by [Claude Code](https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A)_