### PR TITLE
chore: add Supabase MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=wdyquwheodarrmwtljqa&features=database%2Caccount%2Cdocs%2Cdebugging%2Cdevelopment%2Cfunctions%2Cbranching%2Cstorage"
+    }
+  }
+}


### PR DESCRIPTION
Adds the hosted Supabase MCP server (`mcp.supabase.com`, scoped to this project ref, features: database/account/docs/debugging/development/functions/branching/storage) to the project-scope `.mcp.json` so every Claude Code session picks it up.

- Contains only the **public** project ref — no secrets. Auth happens per-user via OAuth on first connect.
- Note for Claude Code on the web: the egress allowlist needs **`mcp.supabase.com`** (a `.com` host — not covered by `*.supabase.co`).

https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A

---
_Generated by [Claude Code](https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A)_