### PR TITLE
chore(mcp): zero-touch Supabase MCP auth via SUPABASE_ACCESS_TOKEN env var

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "supabase": {
       "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=wdyquwheodarrmwtljqa&features=database%2Caccount%2Cdocs%2Cdebugging%2Cdevelopment%2Cfunctions%2Cbranching%2Cstorage"
+      "url": "https://mcp.supabase.com/mcp?project_ref=wdyquwheodarrmwtljqa&features=database%2Caccount%2Cdocs%2Cdebugging%2Cdevelopment%2Cfunctions%2Cbranching%2Cstorage",
+      "headers": {
+        "Authorization": "Bearer ${SUPABASE_ACCESS_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
Per-session OAuth for the Supabase MCP is friction on Claude Code cloud sessions: the OAuth token store lives in the ephemeral container, so every new session would repeat the authorize-and-paste-callback dance.

Claude Code expands `${VAR}` in `.mcp.json`, so this switches the hosted endpoint to header auth:

```json
"headers": { "Authorization": "Bearer ${SUPABASE_ACCESS_TOKEN}" }
```

With `SUPABASE_ACCESS_TOKEN` set in the **execution-environment variables** (injected into every container), sessions become zero-touch. No secret enters the repo.

Setup (one time):
1. Supabase Dashboard → Account → **Access Tokens** → Generate (e.g. `claude-code-mcp`)
2. Claude Code environment settings → environment variables → `SUPABASE_ACCESS_TOKEN=<token>`
3. Egress allowlist needs `mcp.supabase.com`

Fallback if the hosted endpoint ever rejects PAT bearer auth: swap to the stdio server (`npx -y @supabase/mcp-server-supabase@latest --project-ref=...` with `SUPABASE_ACCESS_TOKEN` in env; requires `api.supabase.com` egress instead).

https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A

---
_Generated by [Claude Code](https://claude.ai/code/session_018DMaDtnqxHRnucm9i1y77A)_