### PR TITLE
fix(sec): disable X-Powered-By response header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -55,6 +55,10 @@ function buildCsp(): string {
 }
 
 const nextConfig: NextConfig = {
+  // SEC: do not advertise the framework. Next.js adds `X-Powered-By: Next.js`
+  // by default; setting this to false removes it.
+  // ZAP 10037 "Server Leaks Information via X-Powered-By" — Refs mattyopon/faultray#172
+  poweredByHeader: false,
   // Optional Upstash backend for src/lib/rate-limit.ts: these packages are
   // intentionally NOT in package.json (operator installs them to opt in).
   // Keep them out of the server bundle so the dynamic import becomes a


### PR DESCRIPTION
## What

Removes the `X-Powered-By: Next.js` response header, which leaks framework information.

ZAP finding **10037 "Server Leaks Information via X-Powered-By"**.

## Change

Single config addition in `next.config.ts`:

```ts
const nextConfig: NextConfig = {
  // SEC: do not advertise the framework. Next.js adds `X-Powered-By: Next.js`
  // by default; setting this to false removes it.
  // ZAP 10037 "Server Leaks Information via X-Powered-By" — Refs mattyopon/faultray#172
  poweredByHeader: false,
  ...
};
```

Confirmed against the **bundled** Next.js 16.2.6 docs (`node_modules/next/dist/docs/01-app/03-api-reference/05-config/01-next-config-js/poweredByHeader.md`) — `poweredByHeader: false` is the supported opt-out in this (modified) version, and the existing `headers()` block does not re-add the header. Repo-wide grep confirms nothing else sets `X-Powered-By`.

Scope is intentionally limited to this one finding. Other ZAP items (CSP `unsafe-inline` #85, COOP, COEP, cache headers) are out of scope.

## 証跡 (verification)

Run in the worktree (exit codes not masked):

| Check | Command | Result |
|-------|---------|--------|
| typecheck | `npm run typecheck` (`tsc --noEmit`) | ✅ PASS (exit 0) |
| lint | `npm run lint` (`eslint`) | ✅ PASS (exit 0) |
| test | `npm test` (`vitest run`) | 277 passed / 1 failed (278 total) |

The single failing test is `tests/quality/build.test.ts` ("next build completes successfully"). It is **not** caused by this change — it is an environment artifact: Turbopack rejects the `node_modules` symlink used to reuse installed deps in the agent worktree (`TurbopackInternalError: Symlink [project]/node_modules is invalid, it points out of the filesystem root`). Verified by stashing this change and re-running the build test on clean `main` — it fails identically. The diff is a 4-line addition to `next.config.ts` only; it does not touch the build.

Refs mattyopon/faultray#172

https://claude.ai/code/session_01ByeqoEtpRmWscckF63PTJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByeqoEtpRmWscckF63PTJM)_