### PR TITLE
docs(env): document missing runtime env vars in .env*.example

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -10,15 +10,19 @@ SUPABASE_SERVICE_ROLE_KEY=your-dev-service-role-key
 NEXT_PUBLIC_API_URL=http://localhost:8000
 FAULTRAY_API_URL=http://localhost:8000
 
-# FaultRay simulation API (browser-exposed; the app reads only this var).
-# Unset/misconfigured = What-If & report runs 5xx ("backend unreachable").
+# FaultRay simulation API (browser-exposed). Preferred var; the app falls back
+# to the legacy NEXT_PUBLIC_API_URL above when this is unset (src/lib/api.ts).
+# Both unset/misconfigured = What-If & report runs 5xx ("backend unreachable").
 NEXT_PUBLIC_FAULTRAY_API_URL=http://localhost:8000
 
 # Stripe (テストモード)
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_test_...
-# Comma-separated price IDs per plan tier; checkout 5xx if the tier is unmapped.
+# Comma-separated price IDs per plan tier; used by the Stripe webhook
+# (src/app/api/stripe/webhook/route.ts) to map a paid priceId back to a tier.
+# A priceId not listed here resolves to no tier, so the webhook keeps the
+# customer's existing plan instead of upgrading (no error/5xx).
 STRIPE_STARTER_PRICE_IDS=price_test_starter
 STRIPE_PRO_PRICE_IDS=price_test_pro
 STRIPE_BUSINESS_PRICE_IDS=price_test_business
@@ -29,7 +33,8 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 ALLOWED_ORIGIN=
 
 # Cron (/api/cron/*) — trial-expiry / trial-reminders jobs.
-# CRON_SECRET unset = cron endpoints reject every caller (401).
+# CRON_SECRET unset = cron endpoints reject every caller (503); a present-but-
+# wrong Bearer token gets 401. See src/lib/cron-auth.ts.
 CRON_SECRET=
 # Optional comma-separated IP allowlist for cron callers (unset = no IP filter).
 CRON_ALLOWED_IPS=
@@ -40,8 +45,9 @@ RESEND_API_KEY=
 # Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
 ADMIN_EMAILS=
 
-# Rate limiting (distributed backend). Both unset = in-memory limiter fallback;
-# set both to enable Upstash, or partial config will fail limiter init.
+# Rate limiting (distributed backend). Set BOTH to enable Upstash; if either is
+# missing (unset or partial config) the limiter silently falls back to the
+# per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 

--- a/.env.development.example
+++ b/.env.development.example
@@ -21,8 +21,10 @@ STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_test_...
 # Comma-separated price IDs per plan tier; used by the Stripe webhook
 # (src/app/api/stripe/webhook/route.ts) to map a paid priceId back to a tier.
-# A priceId not listed here resolves to no tier, so the webhook keeps the
-# customer's existing plan instead of upgrading (no error/5xx).
+# IMPORTANT: list EVERY active price ID. On a customer.subscription.updated event
+# an active subscription whose priceId is missing here resolves to no tier and is
+# DOWNGRADED to `free` (lost paid entitlements), NOT kept on its current plan.
+# Add new/renamed Stripe prices here before they go live.
 STRIPE_STARTER_PRICE_IDS=price_test_starter
 STRIPE_PRO_PRICE_IDS=price_test_pro
 STRIPE_BUSINESS_PRICE_IDS=price_test_business
@@ -45,9 +47,11 @@ RESEND_API_KEY=
 # Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
 ADMIN_EMAILS=
 
-# Rate limiting (distributed backend). Set BOTH to enable Upstash; if either is
-# missing (unset or partial config) the limiter silently falls back to the
-# per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
+# Rate limiting (distributed backend). Enabling Upstash needs BOTH (1) these two
+# env vars AND (2) the @upstash/ratelimit + @upstash/redis packages installed —
+# they are optional, dynamically imported, and NOT in package.json by default
+# (#116). If the env vars OR the packages are missing, the limiter silently falls
+# back to the per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 

--- a/.env.development.example
+++ b/.env.development.example
@@ -10,16 +10,51 @@ SUPABASE_SERVICE_ROLE_KEY=your-dev-service-role-key
 NEXT_PUBLIC_API_URL=http://localhost:8000
 FAULTRAY_API_URL=http://localhost:8000
 
+# FaultRay simulation API (browser-exposed; the app reads only this var).
+# Unset/misconfigured = What-If & report runs 5xx ("backend unreachable").
+NEXT_PUBLIC_FAULTRAY_API_URL=http://localhost:8000
+
 # Stripe (テストモード)
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_test_...
+# Comma-separated price IDs per plan tier; checkout 5xx if the tier is unmapped.
+STRIPE_STARTER_PRICE_IDS=price_test_starter
+STRIPE_PRO_PRICE_IDS=price_test_pro
+STRIPE_BUSINESS_PRICE_IDS=price_test_business
 
 # Site URL (開発用)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# Extra cross-origin allowlisted for the API (CORS). Unset = cross-origin 403.
+ALLOWED_ORIGIN=
 
-# GA4 (開発では無効化推奨)
+# Cron (/api/cron/*) — trial-expiry / trial-reminders jobs.
+# CRON_SECRET unset = cron endpoints reject every caller (401).
+CRON_SECRET=
+# Optional comma-separated IP allowlist for cron callers (unset = no IP filter).
+CRON_ALLOWED_IPS=
+
+# Email — transactional mail via Resend. Unset = trial/notification mail silently no-ops.
+RESEND_API_KEY=
+
+# Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
+ADMIN_EMAILS=
+
+# Rate limiting (distributed backend). Both unset = in-memory limiter fallback;
+# set both to enable Upstash, or partial config will fail limiter init.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Security — AES-256-GCM key for src/lib/crypto.ts (32 bytes, base64).
+# Unset = encrypt/decrypt paths throw at runtime (5xx).
+ENCRYPTION_KEY=
+# IP allowlist enforced by src/proxy.ts. Unset = no IP restriction.
+ALLOWED_IPS=
+
+# Analytics / monitoring (開発では無効化推奨; unset = feature simply off, no error).
 # NEXT_PUBLIC_GA_ID=
+NEXT_PUBLIC_HOTJAR_ID=
+NEXT_PUBLIC_SENTRY_DSN=
 
 # Sendgrid (開発では無効化推奨)
 # SENDGRID_API_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -7,6 +7,9 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # ── Site ─────────────────────────────────────────────────────────────
 # Canonical origin; used for CSRF Origin allowlist + CORS headers
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# Extra cross-origin allowlisted for the API (src/lib/api-auth.ts CORS).
+# Unset = only NEXT_PUBLIC_SITE_URL is allowed; cross-origin API calls 403.
+ALLOWED_ORIGIN=
 
 # ── FaultRay simulation API ──────────────────────────────────────────
 # Python engine URL. Leave empty to use the local mock.

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -10,15 +10,19 @@ SUPABASE_SERVICE_ROLE_KEY=your-staging-service-role-key
 NEXT_PUBLIC_API_URL=https://api-staging.faultray.com
 FAULTRAY_API_URL=https://api-staging.faultray.com
 
-# FaultRay simulation API (browser-exposed; the app reads only this var).
-# Unset/misconfigured = What-If & report runs 5xx ("backend unreachable").
+# FaultRay simulation API (browser-exposed). Preferred var; the app falls back
+# to the legacy NEXT_PUBLIC_API_URL above when this is unset (src/lib/api.ts).
+# Both unset/misconfigured = What-If & report runs 5xx ("backend unreachable").
 NEXT_PUBLIC_FAULTRAY_API_URL=https://api-staging.faultray.com
 
 # Stripe (テストモード)
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_staging_...
-# Comma-separated price IDs per plan tier; checkout 5xx if the tier is unmapped.
+# Comma-separated price IDs per plan tier; used by the Stripe webhook
+# (src/app/api/stripe/webhook/route.ts) to map a paid priceId back to a tier.
+# A priceId not listed here resolves to no tier, so the webhook keeps the
+# customer's existing plan instead of upgrading (no error/5xx).
 STRIPE_STARTER_PRICE_IDS=price_staging_starter
 STRIPE_PRO_PRICE_IDS=price_staging_pro
 STRIPE_BUSINESS_PRICE_IDS=price_staging_business
@@ -29,7 +33,8 @@ NEXT_PUBLIC_SITE_URL=https://staging.faultray.com
 ALLOWED_ORIGIN=
 
 # Cron (/api/cron/*) — trial-expiry / trial-reminders jobs.
-# CRON_SECRET unset = cron endpoints reject every caller (401).
+# CRON_SECRET unset = cron endpoints reject every caller (503); a present-but-
+# wrong Bearer token gets 401. See src/lib/cron-auth.ts.
 CRON_SECRET=
 # Optional comma-separated IP allowlist for cron callers (unset = no IP filter).
 CRON_ALLOWED_IPS=
@@ -40,8 +45,9 @@ RESEND_API_KEY=
 # Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
 ADMIN_EMAILS=
 
-# Rate limiting (distributed backend). Both unset = in-memory limiter fallback;
-# set both to enable Upstash, or partial config will fail limiter init.
+# Rate limiting (distributed backend). Set BOTH to enable Upstash; if either is
+# missing (unset or partial config) the limiter silently falls back to the
+# per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -21,8 +21,10 @@ STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_staging_...
 # Comma-separated price IDs per plan tier; used by the Stripe webhook
 # (src/app/api/stripe/webhook/route.ts) to map a paid priceId back to a tier.
-# A priceId not listed here resolves to no tier, so the webhook keeps the
-# customer's existing plan instead of upgrading (no error/5xx).
+# IMPORTANT: list EVERY active price ID. On a customer.subscription.updated event
+# an active subscription whose priceId is missing here resolves to no tier and is
+# DOWNGRADED to `free` (lost paid entitlements), NOT kept on its current plan.
+# Add new/renamed Stripe prices here before they go live.
 STRIPE_STARTER_PRICE_IDS=price_staging_starter
 STRIPE_PRO_PRICE_IDS=price_staging_pro
 STRIPE_BUSINESS_PRICE_IDS=price_staging_business
@@ -45,9 +47,11 @@ RESEND_API_KEY=
 # Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
 ADMIN_EMAILS=
 
-# Rate limiting (distributed backend). Set BOTH to enable Upstash; if either is
-# missing (unset or partial config) the limiter silently falls back to the
-# per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
+# Rate limiting (distributed backend). Enabling Upstash needs BOTH (1) these two
+# env vars AND (2) the @upstash/ratelimit + @upstash/redis packages installed —
+# they are optional, dynamically imported, and NOT in package.json by default
+# (#116). If the env vars OR the packages are missing, the limiter silently falls
+# back to the per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -10,13 +10,49 @@ SUPABASE_SERVICE_ROLE_KEY=your-staging-service-role-key
 NEXT_PUBLIC_API_URL=https://api-staging.faultray.com
 FAULTRAY_API_URL=https://api-staging.faultray.com
 
+# FaultRay simulation API (browser-exposed; the app reads only this var).
+# Unset/misconfigured = What-If & report runs 5xx ("backend unreachable").
+NEXT_PUBLIC_FAULTRAY_API_URL=https://api-staging.faultray.com
+
 # Stripe (テストモード)
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_staging_...
+# Comma-separated price IDs per plan tier; checkout 5xx if the tier is unmapped.
+STRIPE_STARTER_PRICE_IDS=price_staging_starter
+STRIPE_PRO_PRICE_IDS=price_staging_pro
+STRIPE_BUSINESS_PRICE_IDS=price_staging_business
 
 # Site URL (ステージング)
 NEXT_PUBLIC_SITE_URL=https://staging.faultray.com
+# Extra cross-origin allowlisted for the API (CORS). Unset = cross-origin 403.
+ALLOWED_ORIGIN=
+
+# Cron (/api/cron/*) — trial-expiry / trial-reminders jobs.
+# CRON_SECRET unset = cron endpoints reject every caller (401).
+CRON_SECRET=
+# Optional comma-separated IP allowlist for cron callers (unset = no IP filter).
+CRON_ALLOWED_IPS=
+
+# Email — transactional mail via Resend. Unset = trial/notification mail silently no-ops.
+RESEND_API_KEY=
+
+# Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
+ADMIN_EMAILS=
+
+# Rate limiting (distributed backend). Both unset = in-memory limiter fallback;
+# set both to enable Upstash, or partial config will fail limiter init.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Security — AES-256-GCM key for src/lib/crypto.ts (32 bytes, base64).
+# Unset = encrypt/decrypt paths throw at runtime (5xx).
+ENCRYPTION_KEY=
+# Staging IP allowlist enforced by src/proxy.ts. Unset = no IP restriction.
+ALLOWED_IPS=
 
 # GA4 (ステージング用測定ID)
 NEXT_PUBLIC_GA_ID=G-STAGING123
+# Analytics / monitoring (unset = feature simply off, no error).
+NEXT_PUBLIC_HOTJAR_ID=
+NEXT_PUBLIC_SENTRY_DSN=


### PR DESCRIPTION
## What & why

Closes **issue #75, item #3** (`.env*.example` missing runtime env vars).

Several `process.env.*` vars read by `src/` were absent from the example env files, so fresh setups silently 5xx. This PR documents **every referenced runtime var** in the example files with **placeholder values** (never a real secret) plus a one-line note on what breaks if the var is unset.

### Authoritative source
`grep -rEo "process\.env\.[A-Z0-9_]+" src/ | sort -u` → 26 distinct vars. Excluded 3 platform-injected vars that never belong in example files (`NODE_ENV`, `VERCEL_ENV`, `VERCEL_URL`, all set automatically by Node/Vercel), leaving **23 documentable runtime vars**. After this PR all 23 are documented in every runtime example file.

> Note: I also found `ALLOWED_ORIGIN` (CORS allowlist in `src/lib/api-auth.ts`) referenced but undocumented — it was **not** in the issue's cited list, but the grep is authoritative, so it is now included.

## Vars added, by file

**`.env.local.example`** (was already nearly complete):
- `ALLOWED_ORIGIN`

**`.env.development.example`** and **`.env.staging.example`** (both were missing the same set):
- `ALLOWED_ORIGIN`
- `NEXT_PUBLIC_FAULTRAY_API_URL` (the app reads only this var; the pre-existing bare `FAULTRAY_API_URL` line is not referenced in `src/` and was left untouched — out of scope)
- `STRIPE_STARTER_PRICE_IDS`, `STRIPE_PRO_PRICE_IDS`, `STRIPE_BUSINESS_PRICE_IDS`
- `CRON_SECRET`, `CRON_ALLOWED_IPS`
- `RESEND_API_KEY`
- `ADMIN_EMAILS`
- `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
- `ENCRYPTION_KEY`
- `ALLOWED_IPS`
- `NEXT_PUBLIC_HOTJAR_ID`, `NEXT_PUBLIC_SENTRY_DSN`

(`.env.staging.local.example` is purely CI/deploy secrets — `SUPABASE_TOKEN`, `VERCEL_TOKEN`, OAuth — none of which are `process.env` runtime references in `src/`, so it is out of scope and unchanged. `NEXT_PUBLIC_GA_ID` is left commented-out in dev by intent.)

Diff is **only** to the three `.env*.example` files (75 insertions, 1 deletion). No TS/config touched. Residual-gap check confirms all 23 documentable vars are present in all three runtime example files; a secret-pattern scan (`sk_live`/`AKIA…`/JWT) finds **placeholders only**.

## 証跡 (checks)

| Check | Command | Result |
|---|---|---|
| Typecheck | `npm run typecheck` (`tsc --noEmit`) | ✅ PASS (exit 0) |
| Lint | `npm run lint` (`eslint`) | ✅ PASS (exit 0) |
| Test | `npm test` (`vitest run`) | 277 / 278 PASS |

The single test failure is **`tests/quality/build.test.ts`** (`next build`), which is **pre-existing and environmental — not caused by this diff**. It is a Turbopack panic during package resolution: `Symlink [project]/node_modules is invalid, it points out of the filesystem root`. This reproduces **identically on a pristine `origin/main` checkout with no edits**, and the test runs `next build` which never reads any `.env*.example` file. Doc-only changes to example env files cannot influence a Turbopack symlink-resolution panic.

Refs #75 (item 3)

https://claude.ai/code/session_01ByeqoEtpRmWscckF63PTJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByeqoEtpRmWscckF63PTJM)_