### PR TITLE
fix: add Cross-Origin-Opener-Policy + COOP header (ZAP #172)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -98,6 +98,22 @@ const nextConfig: NextConfig = {
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          // ZAP #172: Cross-Origin-Opener-Policy isolates this top-level browsing
+          // context from cross-origin openers (Spectre / tab-nabbing mitigation).
+          // We use `same-origin-allow-popups` (NOT bare `same-origin`): the
+          // allow-popups form keeps a reference to popups WE open, so OAuth popup
+          // logins (Google / GitHub via Supabase) and Stripe popups keep working,
+          // while still severing the opener link for cross-origin pages that open us.
+          {
+            key: "Cross-Origin-Opener-Policy",
+            value: "same-origin-allow-popups",
+          },
+          // ZAP #172: Cross-Origin-Embedder-Policy (COEP: require-corp) is
+          // intentionally DEFERRED. Enabling it would force every cross-origin
+          // resource (Supabase, Stripe, Google Fonts, GA4/Hotjar, OG images) to
+          // opt in via a Cross-Origin-Resource-Policy / CORP header; any resource
+          // that does not would be blocked, almost certainly breaking the app.
+          // Tracked separately in mattyopon/faultray#172 (follow-up).
           // SEC-03: Strict CSP — replaces the previous frame-ancestors-only policy
           {
             key: "Content-Security-Policy",

--- a/tests/security/csp.test.ts
+++ b/tests/security/csp.test.ts
@@ -31,6 +31,19 @@ describe("L8: Content Security Policy", () => {
     expect(configContent).toContain("frame-ancestors 'none'");
   });
 
+  it("sets Cross-Origin-Opener-Policy as same-origin-allow-popups (ZAP #172)", () => {
+    // allow-popups preserves OAuth popup logins; bare same-origin would break them.
+    expect(configContent).toContain("Cross-Origin-Opener-Policy");
+    expect(configContent).toContain("same-origin-allow-popups");
+  });
+
+  it("does NOT enable Cross-Origin-Embedder-Policy / require-corp (deferred, ZAP #172)", () => {
+    // COEP would force CORP opt-in on every cross-origin resource and break the app.
+    // Assert it is not set as a response header KEY. (The deferral rationale in
+    // next.config.ts mentions "require-corp" in a comment, so don't grep raw text.)
+    expect(configContent).not.toMatch(/key:\s*["']Cross-Origin-Embedder-Policy["']/);
+  });
+
   it("applies headers to all routes", () => {
     // The source pattern should cover all routes
     expect(configContent).toMatch(/source:\s*["']\/(.*?)["']/);

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
       ]
     }


### PR DESCRIPTION
## What
Adds `Cross-Origin-Opener-Policy: same-origin-allow-popups` in `next.config.ts` and `vercel.json`, closing the COOP-missing part of ZAP #172.

## Why `allow-popups` / why COEP is deferred
- `same-origin-allow-popups` preserves OAuth popup logins (Google/GitHub via Supabase) and Stripe popups, while severing the opener link for cross-origin pages that open us (Spectre / tab-nabbing mitigation).
- **COEP (`require-corp`) is deliberately NOT added** (documented inline): it would force CORP opt-in on every cross-origin resource (Supabase, Stripe, fonts, GA4/Hotjar) and almost certainly break the app. Tracked for follow-up in #172.
- Existing `X-Frame-Options` / `X-Content-Type-Options` / `Referrer-Policy` / strict CSP were already present and left unchanged.

## Tests
- `tests/security/csp.test.ts`: +2 regression tests (COOP set as `same-origin-allow-popups`; COEP not enabled as a header).
- typecheck ✅, lint ✅, vitest full suite ✅ (280/280).

## Verification plan
After CI + Codex review: verify on the Vercel preview that the COOP header is present **and** OAuth login + cross-origin resources still work, before merge.

Refs mattyopon/faultray#172

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByeqoEtpRmWscckF63PTJM)_