### PR TITLE
feat(security): nonce-based CSP (#85) + shared rate-limit backend guard (#116)

### DIFF
--- a/docs/csp-nonce-plan.md
+++ b/docs/csp-nonce-plan.md
@@ -1,37 +1,69 @@
-# CSP nonce migration plan (#32)
+# CSP nonce migration plan (#32 / #85)
 
-Current state: `next.config.ts` serves
+Previous state: `next.config.ts` served
 ```
 Content-Security-Policy: script-src 'self' 'unsafe-inline' ...; style-src 'self' 'unsafe-inline' ...;
 ```
 
 `'unsafe-inline'` neutralises the main value of CSP (inline XSS blocking).
-Removing it requires nonce-tagging every inline `<script>` and `<style>`
-site produced by Next.js + the app.
+Removing it requires nonce-tagging every executable inline `<script>` Next.js +
+the app produce. ZAP (mattyopon/faultray#172) flags both `script-src` and
+`style-src` `'unsafe-inline'`.
 
 ## Phases
 
-### Phase 1 — scaffolding (THIS PR)
-- [x] `src/middleware.ts` generates a per-request nonce
-- [x] Nonce flows through `x-faultray-nonce` request + response header
+### Phase 1 — scaffolding (done)
+- [x] `src/proxy.ts` generates a per-request nonce
+- [x] Nonce flows through the `x-faultray-nonce` request header
 - [x] This doc tracks the plan
 
-### Phase 2 — consumer opt-in
-- [ ] Root layout reads the nonce via `next/headers` and passes it into
-      every `<Script>` and `<style>` tag it emits
-- [ ] `CookieConsent`, `language-switcher`, analytics snippets read the
-      nonce attribute
+### Phase 2 — consumer opt-in (done, #85)
+- [x] CSP generation moved out of `next.config.ts` into `src/lib/csp.ts`
+      (`buildCsp`), produced per request by `src/proxy.ts` so it can carry the
+      nonce. `next.config.ts` no longer sets a CSP header (avoids a duplicate,
+      intersected policy).
+- [x] Root layout (`src/app/layout.tsx`) reads the nonce via `next/headers` and
+      stamps it on every executable `<script>` / `next/script` `<Script>` it
+      emits (JSON-LD, GA4 loader + init, Hotjar init, the pre-hydration theme
+      script). Reading `headers()` is gated on the strict flag so static
+      rendering is preserved when strict CSP is off.
+- [x] Next.js auto-applies the nonce to its own framework/inline scripts: in
+      strict mode the proxy also forwards the policy on the **request**
+      `Content-Security-Policy` header, from which Next extracts `'nonce-…'`.
 
-### Phase 3 — enforce
-- [ ] Update `next.config.ts` CSP: replace `'unsafe-inline'` with
-      `'nonce-${nonce}'` (value comes from middleware).
-- [ ] Ship behind `FAULTRAY_CSP_STRICT=1` env for 1 release cycle so
-      breakage can be detected without rollback.
-- [ ] Flip default on once telemetry is clean.
+      Note: locale JSON-LD blocks (`/en`, `/ja`) use
+      `type="application/ld+json"`, which is a non-executed *data block* not
+      subject to `script-src`, so they are intentionally left un-nonced. If
+      preview telemetry shows them blocked, nonce them the same way.
+
+### Phase 3 — enforce (done behind a flag, #85)
+- [x] `buildCsp({ strict: true, nonce })` replaces `'unsafe-inline'` with
+      `'nonce-${nonce}' 'strict-dynamic'` on `script-src` and `'nonce-${nonce}'`
+      on `style-src`. Inline style *attributes* (React `style={{…}}`, which a
+      nonce cannot cover) are kept working via `style-src-attr 'unsafe-inline'`,
+      so `style-src` itself is `unsafe-inline`-free.
+- [x] Strict mode ships behind `FAULTRAY_CSP_STRICT=1` so the change can be
+      verified on a preview deploy without a production rollback. When unset,
+      `buildCsp` returns the historical `'unsafe-inline'` policy unchanged and
+      pages render statically as before.
+- [ ] **Operator step:** set `FAULTRAY_CSP_STRICT=1` on a Vercel **preview**
+      deploy and verify (no CSP violations in the console; GA4 / Hotjar /
+      Stripe load; fonts + inline styles render; hydration works on app pages).
+- [ ] Flip the default on (set `FAULTRAY_CSP_STRICT=1` in production) once
+      preview telemetry is clean, then drop the flag and make strict the default
+      in a follow-up.
+
+## Tradeoff: dynamic rendering
+
+Nonce-based CSP requires per-request rendering, so when `FAULTRAY_CSP_STRICT=1`
+every page is dynamically rendered (no static optimization / CDN caching, higher
+server cost). This is why it is staged behind the flag rather than flipped on
+unconditionally. With the flag off there is **no** rendering change.
 
 ## Why not cut over immediately
 
-Next.js 16 still ships some internal inline scripts (hydration marker,
-route prefetch) whose nonce propagation is not guaranteed across
-versions. A progressive migration lets us stage verification without
-bricking hydration for every user.
+Next.js 16 ships internal inline scripts (hydration marker, route prefetch)
+whose nonce propagation should be handled automatically via the request CSP
+header, but cannot be browser-verified from CI here. A flag-gated rollout lets
+the nonce path be validated on a preview before it becomes the production
+default, without bricking hydration for every user.

--- a/next.config.ts
+++ b/next.config.ts
@@ -59,20 +59,11 @@ const nextConfig: NextConfig = {
   // by default; setting this to false removes it.
   // ZAP 10037 "Server Leaks Information via X-Powered-By" — Refs mattyopon/faultray#172
   poweredByHeader: false,
-  // Optional Upstash backend for src/lib/rate-limit.ts: these packages are
-  // intentionally NOT in package.json (operator installs them to opt in).
-  // Keep them out of the server bundle so the dynamic import becomes a
-  // runtime require (guarded by try/catch), and suppress the expected
-  // module-not-found build warning when they are absent.
+  // #116: the Upstash rate-limit backend (@upstash/ratelimit + @upstash/redis)
+  // are first-class dependencies. Keep them server-external so they are loaded
+  // at runtime (only when UPSTASH_* env is configured, via the lazy dynamic
+  // import in src/lib/rate-limit.ts) rather than bundled into every server chunk.
   serverExternalPackages: ["@upstash/ratelimit", "@upstash/redis"],
-  turbopack: {
-    ignoreIssue: [
-      {
-        path: "**/src/lib/rate-limit.ts",
-        title: /Module not found/,
-      },
-    ],
-  },
   async headers() {
     // #88 (P3-4): CORS allowlist を server-only env で管理する。
     //   ALLOWED_ORIGIN : single origin。next.config.ts の static header は

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,58 +1,11 @@
 import type { NextConfig } from "next";
 
-// SEC-03: Build a strict Content-Security-Policy.
-// Each source list is intentionally minimal — only domains actually loaded by the app.
-//
-// default-src 'self'            — fallback: block everything not listed below
-// script-src                    — Next.js inline chunks + GA4 + Hotjar + Stripe
-// style-src                     — Next.js injects inline <style> tags at runtime
-// img-src                       — self, data URIs, OG images served via Vercel image optimizer,
-//                                 Google/Hotjar tracking pixels
-// font-src                      — Google Fonts static assets
-// connect-src                   — Supabase API, GA4 collect, Hotjar ingestion, Stripe API
-// frame-src                     — Stripe hosted fields run inside an iframe
-// frame-ancestors 'none'        — prevent clickjacking (redundant with X-Frame-Options: DENY)
-// base-uri 'self'               — prevent <base href> hijack
-// form-action 'self'            — prevent form POST to attacker origin
-// upgrade-insecure-requests     — force HTTPS for mixed-content resources
-function buildCsp(): string {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-  // Strip trailing slash for use as a CSP source
-  const supabaseOrigin = supabaseUrl.replace(/\/$/, "");
-
-  const directives: string[] = [
-    "default-src 'self'",
-    // TODO: nonce-based CSPに移行すべき。nonce-basedにすれば 'unsafe-inline' を除去できる。
-    // ただし Next.js の静的エクスポートおよびインラインスクリプト注入との互換性のために
-    // 現状は 'unsafe-inline' を維持している。移行にはカスタムサーバー or middleware での
-    // nonce生成と、すべてのインライン <script> / <style> への nonce属性付与が必要。
-    // 参照: https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy
-    "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.hotjar.com https://script.hotjar.com https://js.stripe.com",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src 'self' data: blob: https://faultray.com https://www.google-analytics.com https://www.googletagmanager.com https://*.hotjar.com",
-    "font-src 'self' https://fonts.gstatic.com",
-    [
-      "connect-src 'self'",
-      supabaseOrigin,
-      "https://www.google-analytics.com",
-      "https://analytics.google.com",
-      "https://stats.g.doubleclick.net",
-      "https://*.hotjar.com",
-      "https://*.hotjar.io",
-      "wss://*.hotjar.com",
-      "https://api.stripe.com",
-    ]
-      .filter(Boolean)
-      .join(" "),
-    "frame-src https://js.stripe.com https://hooks.stripe.com",
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "upgrade-insecure-requests",
-  ];
-
-  return directives.join("; ");
-}
+// SEC-03 / #32 / #85: the Content-Security-Policy is now generated per request
+// in src/proxy.ts (so it can carry a per-request nonce under FAULTRAY_CSP_STRICT
+// and remove 'unsafe-inline'). It is intentionally NOT set here — a static
+// next.config header cannot vary per request, and setting CSP in both places
+// would emit two CSP headers that the browser enforces as their intersection.
+// See src/lib/csp.ts (buildCsp) and docs/csp-nonce-plan.md.
 
 const nextConfig: NextConfig = {
   // SEC: do not advertise the framework. Next.js adds `X-Powered-By: Next.js`
@@ -105,11 +58,10 @@ const nextConfig: NextConfig = {
           // opt in via a Cross-Origin-Resource-Policy / CORP header; any resource
           // that does not would be blocked, almost certainly breaking the app.
           // Tracked separately in mattyopon/faultray#172 (follow-up).
-          // SEC-03: Strict CSP — replaces the previous frame-ancestors-only policy
-          {
-            key: "Content-Security-Policy",
-            value: buildCsp(),
-          },
+          //
+          // Content-Security-Policy is set per request in src/proxy.ts (nonce
+          // support under FAULTRAY_CSP_STRICT), not here — see the note at the
+          // top of this file.
           // SEC-04: Prevent MIME-type sniffing attacks on downloads
           { key: "X-DNS-Prefetch-Control", value: "on" },
           // SEC-05: Strict Transport Security (max-age 1 year, include subdomains)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.4",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
         "next": "^16.2.6",
@@ -2916,6 +2918,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -7889,6 +7924,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.27.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/check-rate-limit-backend.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -21,6 +22,8 @@
   "dependencies": {
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.4",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
     "next": "^16.2.6",

--- a/scripts/check-rate-limit-backend.mjs
+++ b/scripts/check-rate-limit-backend.mjs
@@ -1,0 +1,72 @@
+// #116: Production deploy guard for the rate-limit backend.
+//
+// The in-memory rate limiter in src/lib/rate-limit.ts is per-process and is
+// trivially bypassed across Vercel serverless instances. To stop a production
+// deploy from silently shipping on that fallback, this guard fails the build
+// when a Vercel *production* build has no shared (Upstash) backend configured.
+//
+// Wired as the npm `prebuild` step, so it runs inside `npm run build` — the
+// command Vercel runs on deploy. It is a NO-OP everywhere except a Vercel
+// production build (VERCEL_ENV === "production"), so CI build checks, preview
+// deploys, local dev and self-hosted builds are unaffected. The runtime
+// request path is never changed (no per-request 500s).
+
+import { fileURLToPath } from "node:url";
+
+/**
+ * Evaluate whether the rate-limit backend configuration is acceptable for the
+ * given environment.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ ok: boolean, enforced: boolean, reason: string }}
+ *   - `ok`: false only when the build should be blocked.
+ *   - `enforced`: whether the guard is active for this env (production build).
+ *   - `reason`: human-readable explanation for logs.
+ */
+export function evaluateRateLimitBackend(env) {
+  const isProdDeploy = env.VERCEL_ENV === "production";
+  const hasUpstash = Boolean(
+    env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
+  );
+
+  if (!isProdDeploy) {
+    return {
+      ok: true,
+      enforced: false,
+      reason: "not a Vercel production build — rate-limit backend guard inactive",
+    };
+  }
+  if (hasUpstash) {
+    return {
+      ok: true,
+      enforced: true,
+      reason: "Upstash shared rate-limit backend configured for production",
+    };
+  }
+  return {
+    ok: false,
+    enforced: true,
+    reason:
+      "VERCEL_ENV=production but UPSTASH_REDIS_REST_URL / " +
+      "UPSTASH_REDIS_REST_TOKEN are not set. Production must not ship on the " +
+      "per-instance in-memory rate limiter (#116). Configure the Upstash " +
+      "backend, or unset VERCEL_ENV for a non-production build.",
+  };
+}
+
+// Run as a CLI when invoked directly (the `prebuild` hook). Importing this file
+// (e.g. from tests) must not exit the process, so gate on the entrypoint.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  process.argv[1] === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const result = evaluateRateLimitBackend(process.env);
+  if (!result.ok) {
+    console.error(`\n[rate-limit guard] BUILD BLOCKED: ${result.reason}\n`);
+    process.exit(1);
+  }
+  if (result.enforced) {
+    console.log(`[rate-limit guard] OK: ${result.reason}`);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Inter, Noto_Sans_JP, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import { AuthProvider } from "@/components/auth-provider";
@@ -150,7 +151,16 @@ const jsonLd = [
   },
 ];
 
-export default function RootLayout({
+// #32 / #85: strict (nonce-based) CSP is staged behind FAULTRAY_CSP_STRICT.
+// When on, the layout reads the per-request nonce (set by src/proxy.ts) and
+// stamps it on every executable inline / third-party <script>, and reading
+// headers() opts the tree into dynamic rendering — which nonce-based CSP
+// requires. When off, we skip headers() entirely so static rendering (and CDN
+// caching) is preserved and scripts run under the historical 'unsafe-inline'
+// policy. See docs/csp-nonce-plan.md.
+const STRICT_CSP = process.env.FAULTRAY_CSP_STRICT === "1";
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -160,6 +170,10 @@ export default function RootLayout({
   // Validate as numeric-only to prevent XSS via env var injection
   const rawHotjarId = process.env.NEXT_PUBLIC_HOTJAR_ID;
   const hotjarId = rawHotjarId && /^\d+$/.test(rawHotjarId) ? rawHotjarId : undefined;
+
+  const nonce = STRICT_CSP
+    ? ((await headers()).get("x-faultray-nonce") ?? undefined)
+    : undefined;
 
   // I18N-04: Detect locale from cookie/Accept-Language for html lang attribute
   // Falls back to "en" for root layout; locale-specific layouts override via their own html element
@@ -180,6 +194,7 @@ export default function RootLayout({
             attacker-controlled value in jsonLd can never terminate the script tag early. */}
         <script
           type="application/ld+json"
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(jsonLd)
               .replace(/</g, "\\u003c")
@@ -195,8 +210,9 @@ export default function RootLayout({
             <Script
               src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
               strategy="afterInteractive"
+              nonce={nonce}
             />
-            <Script id="ga4-init" strategy="afterInteractive">
+            <Script id="ga4-init" strategy="afterInteractive" nonce={nonce}>
               {`
                 (function(){
                   var consent = typeof localStorage !== 'undefined'
@@ -214,7 +230,7 @@ export default function RootLayout({
         )}
         {/* ANALYTICS-04: Hotjar — heatmap & session recording (consent-gated) */}
         {hotjarId && (
-          <Script id="hotjar-init" strategy="afterInteractive">
+          <Script id="hotjar-init" strategy="afterInteractive" nonce={nonce}>
             {`(function(){
               var consent=typeof localStorage!=='undefined'?localStorage.getItem('faultray_cookie_consent'):null;
               if(consent!=='accepted')return;
@@ -231,6 +247,7 @@ export default function RootLayout({
         )}
         {/* Inline script runs before React hydration — prevents layout shift */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `(function(){
               var p=window.location.pathname;

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,109 @@
+/**
+ * Content-Security-Policy builder (#32 / #85, ZAP mattyopon/faultray#172).
+ *
+ * Two modes:
+ *  - default (`strict: false`): keeps `'unsafe-inline'` on script-src/style-src.
+ *    This is the historical policy, served while the nonce migration is staged
+ *    behind `FAULTRAY_CSP_STRICT`. Output is byte-for-byte the policy that used
+ *    to live in next.config.ts, so moving CSP generation into src/proxy.ts does
+ *    not change the live default policy.
+ *  - strict (`strict: true` + a per-request `nonce`): removes `'unsafe-inline'`
+ *    from script-src (replaced by `'nonce-…'` + `'strict-dynamic'`) and from
+ *    style-src ELEMENTS (replaced by `'nonce-…'`). Inline style ATTRIBUTES —
+ *    which React emits for `style={{…}}` and which a nonce cannot cover — are
+ *    still permitted via `style-src-attr 'unsafe-inline'`, so the directive ZAP
+ *    flags (`style-src 'unsafe-inline'`) no longer carries it. `'unsafe-eval'`
+ *    is added to script-src in development only (React's dev error overlay).
+ *
+ * The strict policy is produced per request by src/proxy.ts (it owns the nonce).
+ * `'strict-dynamic'` makes CSP3 browsers ignore the host allowlist and trust
+ * scripts loaded by an already-trusted (nonced) script; the explicit GA/Hotjar/
+ * Stripe hosts are retained as a CSP2 fallback for older browsers.
+ */
+export interface CspOptions {
+  strict: boolean;
+  isDev: boolean;
+  /** Supabase project origin (no trailing slash) for connect-src. */
+  supabaseOrigin: string;
+  /** Per-request nonce; required for strict mode to take effect. */
+  nonce?: string;
+}
+
+const IMG_SRC =
+  "img-src 'self' data: blob: https://faultray.com https://www.google-analytics.com https://www.googletagmanager.com https://*.hotjar.com";
+const FONT_SRC = "font-src 'self' https://fonts.gstatic.com";
+const FRAME_SRC = "frame-src https://js.stripe.com https://hooks.stripe.com";
+const SCRIPT_HOSTS = [
+  "https://www.googletagmanager.com",
+  "https://static.hotjar.com",
+  "https://script.hotjar.com",
+  "https://js.stripe.com",
+];
+
+function connectSrc(supabaseOrigin: string): string {
+  return [
+    "connect-src 'self'",
+    supabaseOrigin,
+    "https://www.google-analytics.com",
+    "https://analytics.google.com",
+    "https://stats.g.doubleclick.net",
+    "https://*.hotjar.com",
+    "https://*.hotjar.io",
+    "wss://*.hotjar.com",
+    "https://api.stripe.com",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function buildCsp({ strict, isDev, supabaseOrigin, nonce }: CspOptions): string {
+  const useNonce = strict && Boolean(nonce);
+
+  if (!useNonce) {
+    // Historical policy — keep identical to the previous next.config.ts output.
+    const directives = [
+      "default-src 'self'",
+      `script-src 'self' 'unsafe-inline' ${SCRIPT_HOSTS.join(" ")}`,
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      IMG_SRC,
+      FONT_SRC,
+      connectSrc(supabaseOrigin),
+      FRAME_SRC,
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "upgrade-insecure-requests",
+    ];
+    return directives.join("; ");
+  }
+
+  // Strict, nonce-based policy.
+  const scriptSrc = [
+    "script-src 'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    isDev ? "'unsafe-eval'" : "",
+    ...SCRIPT_HOSTS, // CSP2 fallback; ignored by CSP3 strict-dynamic browsers
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const directives = [
+    "default-src 'self'",
+    scriptSrc,
+    `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`,
+    // React inline style attributes (style={{…}}) cannot be nonced; permit them
+    // at the attribute level only so style-src itself stays unsafe-inline-free.
+    "style-src-attr 'unsafe-inline'",
+    IMG_SRC,
+    FONT_SRC,
+    connectSrc(supabaseOrigin),
+    FRAME_SRC,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+  ];
+  return directives.join("; ");
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -2,14 +2,17 @@
  * Rate limiter for Next.js API routes (#25).
  *
  * Strategy:
- *   1. If UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN are set
- *      AND @upstash/ratelimit is installed → use the distributed
- *      token-bucket backend that works across Vercel serverless
- *      invocations.
- *   2. Else → fall back to the in-memory sliding window. This path
- *      is only effective on single-process deployments (local dev,
- *      self-hosted). Vercel serverless per-instance processes will
- *      **not** share counters — documented limitation.
+ *   1. If UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN are set →
+ *      use the distributed sliding-window backend (@upstash/ratelimit +
+ *      @upstash/redis, first-class deps as of #116) that shares counters
+ *      across Vercel serverless invocations.
+ *   2. Else → fall back to the in-memory sliding window. This path is only
+ *      effective on single-process deployments (local dev, self-hosted).
+ *      Vercel serverless per-instance processes do **not** share counters.
+ *      To stop production from silently shipping on this fallback, a
+ *      build-time guard (scripts/check-rate-limit-backend.mjs, wired as the
+ *      `prebuild` step) fails a Vercel production build when the Upstash env
+ *      is absent (#116). The runtime request path is unchanged.
  *
  * The public API (applyRateLimit, rateLimit, getClientIp) is stable
  * across both backends.
@@ -55,17 +58,23 @@ async function _getUpstashClient(): Promise<unknown | null> {
   }
 
   try {
-    // Dynamic import so the dependency stays optional. Expect-error on
-    // both lines because these packages are not in package.json — the
-    // operator installs them only when opting into Upstash backend.
-    // @ts-expect-error optional-peer-dep
+    // Lazy dynamic import: only pull the Upstash SDK into the runtime when the
+    // backend is actually configured, keeping cold-starts light on the
+    // in-memory path. The packages are first-class dependencies (#116), so no
+    // optional-peer-dep / @ts-expect-error handling is needed.
     const { Ratelimit } = await import("@upstash/ratelimit");
-    // @ts-expect-error optional-peer-dep
     const { Redis } = await import("@upstash/redis");
     const redis = new Redis({ url, token });
     _upstashClient = { Ratelimit, redis };
     return _upstashClient;
-  } catch {
+  } catch (err) {
+    // The env is configured but client init failed (bad URL/token, network).
+    // Surface it rather than silently degrading to the per-instance limiter.
+    console.error(
+      "[rate-limit] Upstash backend init failed despite configuration — " +
+        "falling back to in-memory:",
+      err instanceof Error ? err.message : err
+    );
     _upstashUnavailable = true;
     return null;
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { buildCsp } from "@/lib/csp";
 
 const locales = ["en", "ja", "de", "fr", "zh", "ko", "es", "pt"];
 const defaultLocale = "en";
@@ -93,13 +94,41 @@ export async function proxy(request: NextRequest) {
     return new NextResponse("Forbidden", { status: 403 });
   }
 
-  // #32 CSP nonce scaffold — generate per-request nonce and expose via
-  // the `x-faultray-nonce` request header so the root layout / <Script>
-  // tags can consume it. Docs: docs/csp-nonce-plan.md
+  // #32 / #85 CSP nonce — generate a per-request nonce and own the
+  // Content-Security-Policy header here (next.config.ts no longer sets it).
+  // Docs: docs/csp-nonce-plan.md
   const _nonceBytes = new Uint8Array(16);
   crypto.getRandomValues(_nonceBytes);
   const nonce = Buffer.from(_nonceBytes).toString("base64");
+
+  // Strict (nonce-based) CSP is staged behind FAULTRAY_CSP_STRICT so the
+  // 'unsafe-inline' removal can be verified on a preview before becoming the
+  // production default (see docs/csp-nonce-plan.md, Phase 3). When the flag is
+  // off, buildCsp() returns the historical 'unsafe-inline' policy unchanged.
+  const strictCsp = process.env.FAULTRAY_CSP_STRICT === "1";
+  const cspValue = buildCsp({
+    strict: strictCsp,
+    isDev: process.env.NODE_ENV === "development",
+    supabaseOrigin: (process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").replace(/\/$/, ""),
+    nonce,
+  });
+
+  // Expose the nonce to the rendering layer so the root layout / <Script> tags
+  // can stamp it on executable inline scripts. In strict mode also forward the
+  // CSP on the *request* so Next.js auto-applies the nonce to its own framework
+  // and inline scripts (it parses `'nonce-…'` out of the request CSP header).
   request.headers.set("x-faultray-nonce", nonce);
+  if (strictCsp) {
+    request.headers.set("content-security-policy", cspValue);
+  }
+
+  // Apply the response CSP to browser-facing document responses. Redirects and
+  // the IP-block/oversize early returns don't carry a rendered document, so the
+  // CSP is set on the pass-through / authenticated responses below.
+  const withCsp = (res: NextResponse): NextResponse => {
+    res.headers.set("Content-Security-Policy", cspValue);
+    return res;
+  };
 
   const { pathname } = request.nextUrl;
 
@@ -164,7 +193,7 @@ export async function proxy(request: NextRequest) {
 
   // If Supabase is not configured, pass through
   if (!supabaseUrl || !supabaseKey) {
-    return NextResponse.next();
+    return withCsp(NextResponse.next({ request }));
   }
 
   let supabaseResponse = NextResponse.next({ request });
@@ -210,7 +239,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  return supabaseResponse;
+  return withCsp(supabaseResponse);
 }
 
 export const config = {

--- a/tests/security/csp-builder.test.ts
+++ b/tests/security/csp-builder.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #85 / ZAP mattyopon/faultray#172 — Content-Security-Policy builder.
+ *
+ * Verifies the two modes of src/lib/csp.ts:
+ *   - default (non-strict): historical 'unsafe-inline' policy, unchanged.
+ *   - strict + nonce: 'unsafe-inline' removed from script-src (nonce +
+ *     strict-dynamic) and style-src (nonce), with inline style *attributes*
+ *     still permitted via style-src-attr.
+ */
+import { describe, it, expect } from "vitest";
+import { buildCsp } from "../../src/lib/csp";
+
+const SUPA = "https://proj.supabase.co";
+
+describe("buildCsp — default (non-strict) policy", () => {
+  const csp = buildCsp({ strict: false, isDev: false, supabaseOrigin: SUPA });
+
+  it("keeps 'unsafe-inline' on script-src and style-src (historical policy)", () => {
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+  });
+
+  it("does not use a nonce or strict-dynamic", () => {
+    expect(csp).not.toContain("nonce-");
+    expect(csp).not.toContain("strict-dynamic");
+  });
+
+  it("retains the clickjacking + base-uri + form-action guards", () => {
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+  });
+
+  it("includes the Supabase origin in connect-src and the third-party hosts", () => {
+    expect(csp).toContain(`connect-src 'self' ${SUPA}`);
+    expect(csp).toContain("https://js.stripe.com");
+    expect(csp).toContain("https://www.googletagmanager.com");
+  });
+
+  it("ignores the nonce / dev flags when not strict", () => {
+    const a = buildCsp({ strict: false, isDev: true, supabaseOrigin: SUPA, nonce: "abc" });
+    expect(a).not.toContain("nonce-");
+    expect(a).not.toContain("'unsafe-eval'");
+  });
+});
+
+describe("buildCsp — strict (nonce-based) policy", () => {
+  const nonce = "TESTNONCE123";
+  const csp = buildCsp({ strict: true, isDev: false, supabaseOrigin: SUPA, nonce });
+
+  it("removes 'unsafe-inline' from script-src and uses nonce + strict-dynamic", () => {
+    const scriptSrc = csp.split("; ").find((d) => d.startsWith("script-src"))!;
+    expect(scriptSrc).toContain(`'nonce-${nonce}'`);
+    expect(scriptSrc).toContain("'strict-dynamic'");
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  it("removes 'unsafe-inline' from style-src (element) and uses a nonce", () => {
+    const styleSrc = csp.split("; ").find((d) => d.startsWith("style-src ") || d === "style-src")!;
+    expect(styleSrc).toContain(`'nonce-${nonce}'`);
+    expect(styleSrc).not.toContain("'unsafe-inline'");
+  });
+
+  it("permits inline style ATTRIBUTES via style-src-attr (React style={{…}})", () => {
+    expect(csp).toContain("style-src-attr 'unsafe-inline'");
+  });
+
+  it("adds object-src 'none' and keeps the other guards", () => {
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("upgrade-insecure-requests");
+  });
+
+  it("keeps the third-party script hosts as a CSP2 fallback", () => {
+    const scriptSrc = csp.split("; ").find((d) => d.startsWith("script-src"))!;
+    expect(scriptSrc).toContain("https://js.stripe.com");
+    expect(scriptSrc).toContain("https://static.hotjar.com");
+  });
+
+  it("adds 'unsafe-eval' to script-src in development only", () => {
+    const dev = buildCsp({ strict: true, isDev: true, supabaseOrigin: SUPA, nonce });
+    expect(dev.split("; ").find((d) => d.startsWith("script-src"))).toContain("'unsafe-eval'");
+    expect(csp.split("; ").find((d) => d.startsWith("script-src"))).not.toContain("'unsafe-eval'");
+  });
+
+  it("falls back to the non-strict policy when strict is set without a nonce", () => {
+    const noNonce = buildCsp({ strict: true, isDev: false, supabaseOrigin: SUPA });
+    expect(noNonce).toContain("script-src 'self' 'unsafe-inline'");
+    expect(noNonce).not.toContain("strict-dynamic");
+  });
+});

--- a/tests/security/csp.test.ts
+++ b/tests/security/csp.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import path from "path";
+import { buildCsp } from "../../src/lib/csp";
 
 const configPath = path.resolve(__dirname, "../../next.config.ts");
 
@@ -26,9 +27,15 @@ describe("L8: Content Security Policy", () => {
     expect(configContent).toContain("strict-origin-when-cross-origin");
   });
 
-  it("sets Content-Security-Policy with frame-ancestors", () => {
-    expect(configContent).toContain("Content-Security-Policy");
-    expect(configContent).toContain("frame-ancestors 'none'");
+  it("builds a Content-Security-Policy with frame-ancestors (now served by proxy.ts)", () => {
+    // CSP moved out of next.config.ts into src/lib/csp.ts / src/proxy.ts so it
+    // can carry a per-request nonce. The default (non-strict) policy must still
+    // include the clickjacking guard.
+    const csp = buildCsp({ strict: false, isDev: false, supabaseOrigin: "" });
+    expect(csp).toContain("frame-ancestors 'none'");
+    // And next.config must NOT also emit a CSP header (that would intersect two
+    // policies in the browser).
+    expect(configContent).not.toMatch(/key:\s*["']Content-Security-Policy["']/);
   });
 
   it("sets Cross-Origin-Opener-Policy as same-origin-allow-popups (ZAP #172)", () => {

--- a/tests/security/rate-limit-backend-guard.test.ts
+++ b/tests/security/rate-limit-backend-guard.test.ts
@@ -1,0 +1,62 @@
+/**
+ * #116: production rate-limit backend guard.
+ *
+ * The build-time guard (scripts/check-rate-limit-backend.mjs, wired as the
+ * npm `prebuild` step) must block a Vercel production build that has no shared
+ * Upstash backend configured, while staying a no-op for every other build
+ * context (CI, preview deploys, local dev, self-hosted).
+ */
+import { describe, it, expect } from "vitest";
+import { evaluateRateLimitBackend } from "../../scripts/check-rate-limit-backend.mjs";
+
+describe("#116: production rate-limit backend guard", () => {
+  it("is inactive (and ok) outside a Vercel production build", () => {
+    expect(evaluateRateLimitBackend({})).toMatchObject({ ok: true, enforced: false });
+    expect(evaluateRateLimitBackend({ VERCEL_ENV: "preview" })).toMatchObject({
+      ok: true,
+      enforced: false,
+    });
+    expect(evaluateRateLimitBackend({ VERCEL_ENV: "development" })).toMatchObject({
+      ok: true,
+      enforced: false,
+    });
+  });
+
+  it("does NOT require Upstash for a preview deploy even if it is otherwise unset", () => {
+    // Preview must keep working on the in-memory fallback without blocking.
+    const r = evaluateRateLimitBackend({ VERCEL_ENV: "preview" });
+    expect(r.ok).toBe(true);
+  });
+
+  it("blocks a production build when no Upstash backend is configured", () => {
+    const r = evaluateRateLimitBackend({ VERCEL_ENV: "production" });
+    expect(r.ok).toBe(false);
+    expect(r.enforced).toBe(true);
+    expect(r.reason).toMatch(/UPSTASH/);
+  });
+
+  it("passes a production build when both Upstash env vars are set", () => {
+    const r = evaluateRateLimitBackend({
+      VERCEL_ENV: "production",
+      UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+      UPSTASH_REDIS_REST_TOKEN: "tkn", // pragma: allowlist secret
+    });
+    expect(r.ok).toBe(true);
+    expect(r.enforced).toBe(true);
+  });
+
+  it("requires BOTH url and token (one alone is insufficient)", () => {
+    expect(
+      evaluateRateLimitBackend({
+        VERCEL_ENV: "production",
+        UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+      }).ok
+    ).toBe(false);
+    expect(
+      evaluateRateLimitBackend({
+        VERCEL_ENV: "production",
+        UPSTASH_REDIS_REST_TOKEN: "tkn", // pragma: allowlist secret
+      }).ok
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two previously-unmerged security changes, rebased onto current `main` (merges cleanly, no conflicts). Both are defensive and gated so they can land safely.

### 1. Nonce-based CSP behind `FAULTRAY_CSP_STRICT` (#85)
- Adds `src/lib/csp.ts` (nonce-based CSP builder) and wires it through `src/proxy.ts` + `src/app/layout.tsx` so the strict policy can drop `'unsafe-inline'`.
- **Feature-flagged** via `FAULTRAY_CSP_STRICT` — off by default, so production behaviour is unchanged until the flag is set. Lets us roll the stricter policy out deliberately.
- Simplifies `next.config.ts` header handling accordingly.
- Tests: `tests/security/csp-builder.test.ts`, updates to `tests/security/csp.test.ts`.

### 2. Real shared (Upstash) rate-limit backend + prod fallback guard (#116)
- `src/lib/rate-limit.ts`: makes the Upstash shared backend a real path (adds `@upstash/ratelimit`, `@upstash/redis`).
- `scripts/check-rate-limit-backend.mjs`: a `prebuild` guard that **fails a Vercel production build** if `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are missing — so prod can't silently ship on the per-instance in-memory limiter. It is a **no-op** everywhere except `VERCEL_ENV=production` (CI build checks, previews, local, self-host are unaffected; no per-request changes).
- Tests: `tests/security/rate-limit-backend-guard.test.ts`.

## Verification (local, on this branch merged with current main)
- lint: clean · `tsc --noEmit`: clean · Vitest: **321 passed** · `next build`: success (prebuild guard no-op locally).

## Notes
- The `@upstash/*` deps are added; production must set `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` or the production build will be blocked by the new guard (that is the intended behaviour of #116).

https://claude.ai/code/session_01S1AVG2LCR1BqkhUCtU1qUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1AVG2LCR1BqkhUCtU1qUF)_