### PR TITLE
chore(dependabot): ignore eslint major until eslint-config-next supports v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # eslint 10 is not yet supported by eslint-config-next's bundled plugins
+    # (eslint-plugin-react/import/jsx-a11y still peer-require eslint <= 9, and
+    # eslint-plugin-react crashes on eslint 10: "getFilename is not a function").
+    # Hold eslint at v9 so the grouped dev-dependencies PR stays mergeable;
+    # remove this once eslint-config-next ships eslint 10 compatibility.
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     # Group dev dependencies into a single PR so security noise stays low.
     # Runtime deps (Next.js / React / Supabase / Stripe) ship individual PRs
     # for visibility.


### PR DESCRIPTION
## Summary

The grouped dev-dependencies Dependabot PR (#145, regenerated as #151) keeps failing CI because it bumps **`eslint` 9 → 10**, but `eslint-config-next`'s bundled plugins don't support ESLint 10 yet:

- `eslint-plugin-react` crashes under ESLint 10 — `TypeError: contextOrFilename.getFilename is not a function` (its React-version detection uses an API removed in ESLint 10).
- `eslint-plugin-import` / `jsx-a11y` / `react` peer-require `eslint <= 9`.

This scopes a Dependabot `ignore` rule to **eslint major updates only**, so:
- the safe dev-dependency updates (playwright, vitest, eslint-config-next minors) still group into a **mergeable** PR, and
- eslint stays at v9 until the ecosystem catches up.

Remove this ignore once `eslint-config-next` ships ESLint 10 compatibility.

## Notes
- Config-only change (`.github/dependabot.yml`); no runtime/code impact.
- Scoped to `eslint` specifically — playwright/vitest major updates are **not** affected (which a blanket `·@·d·ependabot i·gnore t·his major version` on the grouped PR would have risked).

https://claude.ai/code/session_01S1AVG2LCR1BqkhUCtU1qUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1AVG2LCR1BqkhUCtU1qUF)_