### PR TITLE
fix(rate-limit): add ALLOW_INMEMORY_RATELIMIT opt-out so prod builds don't hard-block

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -47,13 +47,20 @@ RESEND_API_KEY=
 # Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
 ADMIN_EMAILS=
 
-# Rate limiting (distributed backend). Enabling Upstash needs BOTH (1) these two
-# env vars AND (2) the @upstash/ratelimit + @upstash/redis packages installed —
-# they are optional, dynamically imported, and NOT in package.json by default
-# (#116). If the env vars OR the packages are missing, the limiter silently falls
-# back to the per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
+# Rate limiting (distributed backend). Set BOTH to use the shared Upstash
+# sliding-window limiter (@upstash/ratelimit + @upstash/redis, first-class deps
+# as of #116). When unset, the limiter falls back to the per-instance in-memory
+# limiter — fine for dev/preview, but NOT shared across serverless instances.
+# See src/lib/rate-limit.ts.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+#
+# Vercel PRODUCTION builds hard-fail (scripts/check-rate-limit-backend.mjs, the
+# npm `prebuild` step) when the two vars above are unset, to stop production
+# shipping on the in-memory limiter (#116). To ship without Upstash on purpose,
+# set ALLOW_INMEMORY_RATELIMIT=1 in the Vercel production env — the build then
+# proceeds with a warning instead of blocking.
+# ALLOW_INMEMORY_RATELIMIT=
 
 # Security — AES-256-GCM key for src/lib/crypto.ts (32 bytes, base64).
 # Unset = encrypt/decrypt paths throw at runtime (5xx).

--- a/.env.local.example
+++ b/.env.local.example
@@ -39,8 +39,10 @@ RESEND_API_KEY=
 ADMIN_EMAILS=
 
 # ── Rate limiting (optional — distributed backend) ───────────────────
-# Requires `npm install @upstash/ratelimit @upstash/redis` to opt in;
-# falls back to the in-memory limiter when unset.
+# Set BOTH to use the shared Upstash limiter (@upstash/ratelimit + @upstash/redis
+# are first-class deps as of #116); falls back to the in-memory limiter when unset.
+# Note: Vercel PRODUCTION builds block when these are unset — set
+# ALLOW_INMEMORY_RATELIMIT=1 there to ship on the in-memory limiter on purpose.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -47,13 +47,20 @@ RESEND_API_KEY=
 # Admin — comma-separated emails allowed at /admin. Unset = nobody can open /admin.
 ADMIN_EMAILS=
 
-# Rate limiting (distributed backend). Enabling Upstash needs BOTH (1) these two
-# env vars AND (2) the @upstash/ratelimit + @upstash/redis packages installed —
-# they are optional, dynamically imported, and NOT in package.json by default
-# (#116). If the env vars OR the packages are missing, the limiter silently falls
-# back to the per-instance in-memory limiter — no error. See src/lib/rate-limit.ts.
+# Rate limiting (distributed backend). Set BOTH to use the shared Upstash
+# sliding-window limiter (@upstash/ratelimit + @upstash/redis, first-class deps
+# as of #116). When unset, the limiter falls back to the per-instance in-memory
+# limiter — fine for dev/preview, but NOT shared across serverless instances.
+# See src/lib/rate-limit.ts.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+#
+# Vercel PRODUCTION builds hard-fail (scripts/check-rate-limit-backend.mjs, the
+# npm `prebuild` step) when the two vars above are unset, to stop production
+# shipping on the in-memory limiter (#116). To ship without Upstash on purpose,
+# set ALLOW_INMEMORY_RATELIMIT=1 in the Vercel production env — the build then
+# proceeds with a warning instead of blocking.
+# ALLOW_INMEMORY_RATELIMIT=
 
 # Security — AES-256-GCM key for src/lib/crypto.ts (32 bytes, base64).
 # Unset = encrypt/decrypt paths throw at runtime (5xx).

--- a/scripts/check-rate-limit-backend.mjs
+++ b/scripts/check-rate-limit-backend.mjs
@@ -10,6 +10,12 @@
 // production build (VERCEL_ENV === "production"), so CI build checks, preview
 // deploys, local dev and self-hosted builds are unaffected. The runtime
 // request path is never changed (no per-request 500s).
+//
+// Escape hatch: set ALLOW_INMEMORY_RATELIMIT=1 (or "true") to ship a production
+// build on the per-instance in-memory limiter on purpose — e.g. before Upstash
+// is provisioned. The build then proceeds but logs a loud WARNING instead of
+// blocking. This is safe-by-default: the variable must be explicitly set; an
+// absent/empty/any-other value keeps the hard block.
 
 import { fileURLToPath } from "node:url";
 
@@ -18,9 +24,10 @@ import { fileURLToPath } from "node:url";
  * given environment.
  *
  * @param {Record<string, string | undefined>} env
- * @returns {{ ok: boolean, enforced: boolean, reason: string }}
+ * @returns {{ ok: boolean, enforced: boolean, warn: boolean, reason: string }}
  *   - `ok`: false only when the build should be blocked.
  *   - `enforced`: whether the guard is active for this env (production build).
+ *   - `warn`: build proceeds but a warning should be surfaced (opt-out path).
  *   - `reason`: human-readable explanation for logs.
  */
 export function evaluateRateLimitBackend(env) {
@@ -28,11 +35,18 @@ export function evaluateRateLimitBackend(env) {
   const hasUpstash = Boolean(
     env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
   );
+  // Explicit operator opt-out (see header). Accepts "1" / "true"
+  // (case-insensitive, trimmed). Anything else — including unset, "", "0",
+  // "false" — does NOT opt out, so the hard block stays the default.
+  const optedOut = ["1", "true"].includes(
+    String(env.ALLOW_INMEMORY_RATELIMIT ?? "").trim().toLowerCase()
+  );
 
   if (!isProdDeploy) {
     return {
       ok: true,
       enforced: false,
+      warn: false,
       reason: "not a Vercel production build — rate-limit backend guard inactive",
     };
   }
@@ -40,17 +54,33 @@ export function evaluateRateLimitBackend(env) {
     return {
       ok: true,
       enforced: true,
+      warn: false,
       reason: "Upstash shared rate-limit backend configured for production",
+    };
+  }
+  if (optedOut) {
+    return {
+      ok: true,
+      enforced: true,
+      warn: true,
+      reason:
+        "VERCEL_ENV=production with no Upstash backend, but " +
+        "ALLOW_INMEMORY_RATELIMIT is set — proceeding on the per-instance " +
+        "in-memory rate limiter by explicit opt-out. Limits are NOT shared " +
+        "across serverless instances and can be bypassed with concurrency " +
+        "(#116). Provision Upstash for production-grade limiting.",
     };
   }
   return {
     ok: false,
     enforced: true,
+    warn: false,
     reason:
       "VERCEL_ENV=production but UPSTASH_REDIS_REST_URL / " +
       "UPSTASH_REDIS_REST_TOKEN are not set. Production must not ship on the " +
       "per-instance in-memory rate limiter (#116). Configure the Upstash " +
-      "backend, or unset VERCEL_ENV for a non-production build.",
+      "backend, set ALLOW_INMEMORY_RATELIMIT=1 to ship on the in-memory " +
+      "limiter on purpose, or unset VERCEL_ENV for a non-production build.",
   };
 }
 
@@ -66,7 +96,9 @@ if (invokedDirectly) {
     console.error(`\n[rate-limit guard] BUILD BLOCKED: ${result.reason}\n`);
     process.exit(1);
   }
-  if (result.enforced) {
+  if (result.warn) {
+    console.warn(`\n[rate-limit guard] WARNING: ${result.reason}\n`);
+  } else if (result.enforced) {
     console.log(`[rate-limit guard] OK: ${result.reason}`);
   }
 }

--- a/tests/security/rate-limit-backend-guard.test.ts
+++ b/tests/security/rate-limit-backend-guard.test.ts
@@ -59,4 +59,46 @@ describe("#116: production rate-limit backend guard", () => {
       }).ok
     ).toBe(false);
   });
+
+  describe("ALLOW_INMEMORY_RATELIMIT opt-out", () => {
+    it("unblocks a production build (with a warning) when explicitly set", () => {
+      for (const v of ["1", "true", "TRUE", " true "]) {
+        const r = evaluateRateLimitBackend({
+          VERCEL_ENV: "production",
+          ALLOW_INMEMORY_RATELIMIT: v,
+        });
+        expect(r.ok, `value=${JSON.stringify(v)}`).toBe(true);
+        expect(r.warn, `value=${JSON.stringify(v)}`).toBe(true);
+      }
+    });
+
+    it("does NOT opt out for falsy / unrelated values — block stays the default", () => {
+      for (const v of ["", "0", "false", "no", "yes", "enabled"]) {
+        const r = evaluateRateLimitBackend({
+          VERCEL_ENV: "production",
+          ALLOW_INMEMORY_RATELIMIT: v,
+        });
+        expect(r.ok, `value=${JSON.stringify(v)}`).toBe(false);
+      }
+    });
+
+    it("prefers a real Upstash backend over the opt-out (no spurious warning)", () => {
+      const r = evaluateRateLimitBackend({
+        VERCEL_ENV: "production",
+        ALLOW_INMEMORY_RATELIMIT: "1",
+        UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+        UPSTASH_REDIS_REST_TOKEN: "tkn", // pragma: allowlist secret
+      });
+      expect(r.ok).toBe(true);
+      expect(r.warn).toBe(false);
+    });
+
+    it("stays a no-op outside production even when the opt-out is set", () => {
+      const r = evaluateRateLimitBackend({
+        VERCEL_ENV: "preview",
+        ALLOW_INMEMORY_RATELIMIT: "1",
+      });
+      expect(r).toMatchObject({ ok: true, enforced: false, warn: false });
+    });
+  });
 });


### PR DESCRIPTION
## Why

The Vercel **production** deploy is failing. The `#116` build guard
`scripts/check-rate-limit-backend.mjs` (wired as the npm `prebuild` step) aborts
any `VERCEL_ENV=production` build when Upstash is not configured:

```
[rate-limit guard] BUILD BLOCKED: VERCEL_ENV=production but UPSTASH_REDIS_REST_URL /
UPSTASH_REDIS_REST_TOKEN are not set. ...
```

This is the guard working as designed (it stops production shipping on the
per-instance in-memory limiter), but with no escape hatch it blocks every
production deploy until Upstash is provisioned.

## What

Add an explicit, **safe-by-default** opt-out: set `ALLOW_INMEMORY_RATELIMIT=1`
(or `true`, case-insensitive) to ship production on the in-memory limiter on
purpose. The build then proceeds with a loud `WARNING` instead of failing.
Absent / empty / `0` / `false` keep the hard block, so a missing backend still
fails by default.

- **guard**: opt-out branch returns `ok + warn`; the CLI prints a `WARNING`
  (not `OK`, not blocked); the block message now points at the opt-out
- **tests**: cover truthy/falsy opt-out values, Upstash precedence over the
  opt-out, and the non-production no-op (9 passing)
- **env examples**: document `ALLOW_INMEMORY_RATELIMIT`; fix the now-stale
  "not in package.json" note (`@upstash/*` are first-class deps as of #116)

## Activating it (manual, after merge)

This code change alone does **not** unblock the deploy — the opt-out must be
turned on in Vercel:

> Vercel → Project → Settings → Environment Variables → add
> `ALLOW_INMEMORY_RATELIMIT` = `1`, scope **Production**, then redeploy.

Alternatively (recommended for real production), configure
`UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` instead — that unblocks the
build *and* keeps the #116 shared-rate-limit protection. The opt-out is for
shipping without Upstash on purpose.

## Verification

- `VERCEL_ENV=production` + opt-out → full `npm run build` succeeds (prebuild
  warns, `next build` completes 92/92 pages, `/admin` stays dynamic)
- `VERCEL_ENV=production` without opt-out and without Upstash → still blocks
  (exit 1)
- `preview` / local / CI → unaffected no-op
- guard unit tests: 9 passing

https://claude.ai/code/session_01Fx3C3s4Cp59YKguQ1cy3PP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fx3C3s4Cp59YKguQ1cy3PP)_