### PR TITLE
security: harden app (SSRF/token-leak, plan-switch authz, open-redirect, PII scoping)

### DIFF
--- a/api/realtime.py
+++ b/api/realtime.py
@@ -320,6 +320,33 @@ def _resolve_user_id(headers):
     return uid if isinstance(uid, str) and _sanitize_uuid(uid) else None
 
 
+def _resolve_user(headers):
+    """Validate the caller's Supabase access token and return the verified
+    user dict ({"id", "email", ...}) from GoTrue ``/auth/v1/user``, or None.
+
+    Authorization decisions MUST use this verified identity — never a
+    client-supplied email/id from the request body (SEC U33).
+    """
+    token = _bearer_token(headers)
+    if not token:
+        return None
+    supabase_url = os.environ.get("NEXT_PUBLIC_SUPABASE_URL", "").rstrip("/")
+    anon_key = os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY", "")
+    if not supabase_url or not anon_key:
+        return None
+    req = urllib.request.Request(
+        f"{supabase_url}/auth/v1/user",
+        method="GET",
+        headers={"apikey": anon_key, "Authorization": f"Bearer {token}"},
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=10)
+        data = json.loads(resp.read())
+    except Exception:
+        return None
+    return data if isinstance(data, dict) and data.get("id") else None
+
+
 def _user_team_ids(user_id: str) -> list:
     """Resolve every team the user belongs to (owned or member).
 
@@ -1120,21 +1147,30 @@ class handler(BaseHTTPRequestHandler):
         self._json(200, {"status": "ok", "engine": "faultray", "version": version})
 
     def _handle_health_post(self, data: dict):
-        action = data.get("action", "admin-check")
-        email = data.get("email", "").strip().lower()
-        if not email:
-            self._json(400, {"error": "Missing email"})
+        # SEC (U33): authorization MUST be derived from the verified session,
+        # never from a client-supplied email. We verify the caller's Supabase
+        # access token and use the email embedded in it; the request-body
+        # `email` is ignored. This removes both the unauthenticated, service-
+        # role plan mutation and the admin-enumeration oracle.
+        user = _resolve_user(self.headers)
+        caller_email = str((user or {}).get("email", "")).strip().lower()
+        if not caller_email:
+            self._json(401, {"error": "Authentication required"})
             return
+        action = data.get("action", "admin-check")
+        is_admin = _is_admin(caller_email)
         if action == "admin-check":
-            self._json(200, {"is_admin": _is_admin(email)})
+            # Authenticated caller learns only their OWN admin status.
+            self._json(200, {"is_admin": is_admin})
         elif action == "switch-plan":
-            if not _is_admin(email):
+            if not is_admin:
                 self._json(403, {"error": "Not authorized"})
                 return
-            result = _switch_plan(email, data.get("plan", ""))
+            # Operate only on the authenticated admin's own account.
+            result = _switch_plan(caller_email, data.get("plan", ""))
             self._json(400 if "error" in result else 200, result)
         else:
-            self._json(200, {"is_admin": _is_admin(email)})
+            self._json(200, {"is_admin": is_admin})
 
     # -----------------------------------------------------------------------
     # Shared helpers

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -101,17 +101,25 @@ export async function DELETE(request: Request) {
     ) {
       try {
         const stripe = new Stripe(stripeSecretKey, { timeout: 30000 });
-        // SEC (U7): paginate ALL subscriptions. `list()` returns only the first
-        // page (default 10), so a customer with >10 subs would keep billing.
-        // `for await` auto-paginates; include all statuses and skip already-
-        // canceled ones.
+        // SEC (U7): cancel ALL subscriptions across pages. `list()` returns
+        // only the first page (default 10), so a customer with >10 subs would
+        // keep billing. Paginate explicitly via has_more / starting_after, and
+        // skip already-canceled ones.
         const toCancel: string[] = [];
-        for await (const sub of stripe.subscriptions.list({
-          customer: stripeCustomerId,
-          status: "all",
-          limit: 100,
-        })) {
-          if (sub.status !== "canceled") toCancel.push(sub.id);
+        let startingAfter: string | undefined;
+        for (;;) {
+          const page = await stripe.subscriptions.list({
+            customer: stripeCustomerId,
+            status: "all",
+            limit: 100,
+            ...(startingAfter ? { starting_after: startingAfter } : {}),
+          });
+          const subs = page.data ?? [];
+          for (const sub of subs) {
+            if (sub.status !== "canceled") toCancel.push(sub.id);
+          }
+          if (!page.has_more || subs.length === 0) break;
+          startingAfter = subs[subs.length - 1].id;
         }
         await Promise.all(
           toCancel.map((id) => stripe.subscriptions.cancel(id))

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -25,14 +25,17 @@ export async function DELETE(request: Request) {
   if (authError) return authError;
 
   // Parse optional confirmation body
-  let body: { confirm?: boolean } = {};
+  let body: { confirm?: unknown } = {};
   try {
-    body = (await request.json()) as { confirm?: boolean };
+    body = (await request.json()) as { confirm?: unknown };
   } catch {
     // No body is fine; we already authenticated above
   }
 
-  if (!body.confirm) {
+  // SEC (U16): require the strict boolean `true`. `!body.confirm` accepted any
+  // truthy value (e.g. {"confirm": 1} or {"confirm": "x"}) → type-confusion that
+  // could trigger an irreversible delete with an unintended payload.
+  if (body.confirm !== true) {
     return NextResponse.json(
       { error: "Confirmation required. Send { \"confirm\": true } in the request body." },
       { status: 400 }
@@ -98,14 +101,23 @@ export async function DELETE(request: Request) {
     ) {
       try {
         const stripe = new Stripe(stripeSecretKey, { timeout: 30000 });
-        const subscriptions = await stripe.subscriptions.list({
+        // SEC (U7): paginate ALL subscriptions. `list()` returns only the first
+        // page (default 10), so a customer with >10 subs would keep billing.
+        // `for await` auto-paginates; include all statuses and skip already-
+        // canceled ones.
+        const toCancel: string[] = [];
+        for await (const sub of stripe.subscriptions.list({
           customer: stripeCustomerId,
-        });
+          status: "all",
+          limit: 100,
+        })) {
+          if (sub.status !== "canceled") toCancel.push(sub.id);
+        }
         await Promise.all(
-          subscriptions.data.map((sub) => stripe.subscriptions.cancel(sub.id))
+          toCancel.map((id) => stripe.subscriptions.cancel(id))
         );
         console.info(
-          `[account/delete] Cancelled ${subscriptions.data.length} Stripe subscription(s) for customer ${stripeCustomerId}`
+          `[account/delete] Cancelled ${toCancel.length} Stripe subscription(s) for customer ${stripeCustomerId}`
         );
       } catch (stripeErr) {
         const msg = stripeErr instanceof Error ? stripeErr.message : "Unknown error";

--- a/src/app/api/cron/trial-expiry/route.ts
+++ b/src/app/api/cron/trial-expiry/route.ts
@@ -23,14 +23,16 @@ export const dynamic = "force-dynamic";
  * Protected by CRON_SECRET (Bearer) to prevent unauthorized invocation.
  */
 export async function POST(request: Request) {
-  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
-  if (limited) return limited;
-
+  // SEC (U17): authenticate BEFORE rate-limiting so unauthenticated callers
+  // can't consume the shared rate-limit bucket and 429 the real cron.
   // Same auth as /api/cron/trial-reminders: constant-time secret compare +
   // optional CRON_ALLOWED_IPS. The inline `!==` check this replaced was
   // timing-variable and ignored the IP allowlist.
   const unauthorized = verifyCronAuth(request);
   if (unauthorized) return unauthorized;
+
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  if (limited) return limited;
 
   const { createClient } = await import("@supabase/supabase-js");
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/app/api/cron/trial-reminders/route.ts
+++ b/src/app/api/cron/trial-reminders/route.ts
@@ -14,11 +14,16 @@ export const dynamic = "force-dynamic";
  * Protected by CRON_SECRET + optional CRON_ALLOWED_IPS (#27).
  */
 export async function POST(request: Request) {
-  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
-  if (limited) return limited;
-
+  // SEC (U17): authenticate BEFORE rate-limiting. The cron-secret check is
+  // cheap, so doing it first means unauthenticated callers are rejected (401)
+  // without consuming the shared rate-limit bucket. Otherwise an attacker could
+  // exhaust the limit and 429 the real cron, so trials never expire / reminders
+  // never send.
   const unauthorized = verifyCronAuth(request);
   if (unauthorized) return unauthorized;
+
+  const limited = await applyRateLimit(request, { limit: 5, windowMs: 60_000 });
+  if (limited) return limited;
 
   const { createClient } = await import("@supabase/supabase-js");
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -73,6 +73,10 @@ export async function GET(request: Request) {
             "[auth/callback] Profile lookup failed:",
             profileError.message
           );
+          // SEC (U29): exchangeCodeForSession already set session cookies. Don't
+          // leave an authenticated-but-broken session reachable — sign out so
+          // the error redirect can't be bypassed by navigating to a gated route.
+          await supabase.auth.signOut();
           return NextResponse.redirect(`${origin}/login?error=profile_setup_failed`);
         }
 
@@ -96,6 +100,9 @@ export async function GET(request: Request) {
               "[auth/callback] Profile bootstrap failed:",
               insertError.message
             );
+            // SEC (U29): fail closed — clear the just-issued session rather than
+            // leaving an authenticated account with no usable profile.
+            await supabase.auth.signOut();
             return NextResponse.redirect(
               `${origin}/login?error=profile_setup_failed`
             );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,16 +8,33 @@ import { Mail, Loader2, CheckCircle2, Lock } from "lucide-react";
 import { useLocale } from "@/lib/useLocale";
 import { appDict } from "@/i18n/app-dict";
 
+// SEC (U29): accept only same-origin internal paths for post-login redirects.
+function isSafeInternalPath(raw: string | null): boolean {
+  if (!raw) return false;
+  // Single leading slash only; reject protocol-relative (//), backslashes
+  // (browsers fold \ → /, enabling //host) and any path traversal.
+  if (!raw.startsWith("/") || raw.startsWith("//")) return false;
+  if (raw.includes("\\") || raw.includes("..")) return false;
+  // Defense in depth: resolving against an arbitrary origin must stay on it.
+  try {
+    const base = "https://faultray.invalid";
+    return new URL(raw, base).origin === base;
+  } catch {
+    return false;
+  }
+}
+
 function LoginForm() {
   const locale = useLocale();
   const t = appDict.login[locale] ?? appDict.login.en;
   const searchParams = useSearchParams();
-  // Validate redirectTo to prevent open redirect — only allow internal paths
+  // SEC (U29): validate redirectTo to prevent open redirect. The previous
+  // check allowed backslashes (`/%5Cevil.com`), which browsers normalize to
+  // `//evil.com` → a protocol-relative external redirect when applied via
+  // `window.location.href`. Reject backslashes and path traversal, and require
+  // a single leading slash. Defense in depth: confirm same-origin via URL().
   const rawRedirectTo = searchParams.get("redirectTo") || "/dashboard";
-  const redirectTo =
-    rawRedirectTo.startsWith("/") && !rawRedirectTo.startsWith("//")
-      ? rawRedirectTo
-      : "/dashboard";
+  const redirectTo = isSafeInternalPath(rawRedirectTo) ? rawRedirectTo : "/dashboard";
   const isProduction = process.env.NEXT_PUBLIC_SITE_URL === "https://faultray.com";
 
   // AUTH-01: Show error message when OAuth fails

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -140,10 +140,17 @@ export default function SettingsPage() {
       // Supabase not configured
     }
     try {
+      // SEC (U33): the server authorizes admin status from the verified access
+      // token, not a body email. Attach the Supabase token; send no email.
+      const { getAccessToken } = await import("@/lib/supabase/client");
+      const accessToken = await getAccessToken();
       const res = await fetch("/api/health", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: user.email }),
+        headers: {
+          "Content-Type": "application/json",
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({ action: "admin-check" }),
       });
       const { is_admin } = await res.json();
       setIsAdmin(!!is_admin);
@@ -168,10 +175,17 @@ export default function SettingsPage() {
     setSwitchingPlan(true);
     setPlanFeedback(null);
     try {
+      // SEC (U33): authorize via the verified token; the server switches only
+      // the authenticated admin's own account (body email is ignored).
+      const { getAccessToken } = await import("@/lib/supabase/client");
+      const accessToken = await getAccessToken();
       const res = await fetch("/api/health", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "switch-plan", email: user.email, plan }),
+        headers: {
+          "Content-Type": "application/json",
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({ action: "switch-plan", plan }),
       });
       const data = await res.json();
       if (data.error) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,13 +1,47 @@
-// LIB-01 fix: validate API_BASE is defined when set to a non-empty value.
+// SEC (U28): validate API_BASE and lock token attachment to a trusted origin.
 //
-// Env var name aligns with .env.local (`NEXT_PUBLIC_FAULTRAY_API_URL`).
-// A legacy `NEXT_PUBLIC_API_URL` is still honored as a fallback so existing
-// deploys and CI envs keep working through the rename rollout; new code
-// should set only NEXT_PUBLIC_FAULTRAY_API_URL.
-const API_BASE =
+// NEXT_PUBLIC_FAULTRAY_API_URL selects the backend origin. Because we attach the
+// Supabase access token (`Authorization: Bearer ...`) to these requests, an
+// attacker-controlled or misconfigured base URL would exfiltrate the token and
+// request bodies (SSRF / token leak). We therefore (1) require the configured
+// base to be a valid absolute https:// URL (http:// only for localhost in dev),
+// and (2) only build requests against that validated origin with a relative
+// path. A malformed/insecure non-empty base fails CLOSED (throws at module
+// load) rather than silently leaking credentials.
+//
+// A legacy `NEXT_PUBLIC_API_URL` is still honored as a fallback through the
+// rename rollout; new code should set only NEXT_PUBLIC_FAULTRAY_API_URL.
+const _RAW_API_BASE = (
   process.env.NEXT_PUBLIC_FAULTRAY_API_URL ||
   process.env.NEXT_PUBLIC_API_URL ||
-  "";
+  ""
+).trim();
+
+function _isLocalhost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+
+/**
+ * Validated, trusted backend origin. "" means same-origin (relative fetch).
+ * Throws on a malformed/insecure configured base so deploys fail closed
+ * instead of attaching the access token to an untrusted host.
+ */
+export const TRUSTED_API_ORIGIN: string = (() => {
+  if (!_RAW_API_BASE) return "";
+  let u: URL;
+  try {
+    u = new URL(_RAW_API_BASE);
+  } catch {
+    throw new Error("[API] NEXT_PUBLIC_FAULTRAY_API_URL must be a valid absolute URL");
+  }
+  if (u.protocol !== "https:" && !(u.protocol === "http:" && _isLocalhost(u.hostname))) {
+    throw new Error("[API] NEXT_PUBLIC_FAULTRAY_API_URL must use https:// (http:// only for localhost)");
+  }
+  return u.origin;
+})();
+
+// Validated prefix for building request URLs ("" = relative/same-origin).
+const API_BASE = TRUSTED_API_ORIGIN ? _RAW_API_BASE.replace(/\/+$/, "") : "";
 
 interface ApiOptions {
   method?: string;
@@ -22,8 +56,20 @@ interface ApiOptions {
 interface CacheEntry { data: unknown; expiresAt: number; }
 const _apiCache = new Map<string, CacheEntry>();
 
+// SEC (U28): never store the raw access token in cache keys, and key by a
+// per-token fingerprint so one user's cached response can't be served to
+// another (cross-user cache poisoning). FNV-1a 32-bit, non-reversible.
+function _fingerprint(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
 function _cacheKey(path: string, token?: string): string {
-  return `${token ?? "anon"}:${path}`;
+  return `${token ? _fingerprint(token) : "anon"}:${path}`;
 }
 
 // FETCHPAT-01: Default timeout 30s to prevent indefinite hangs
@@ -52,8 +98,20 @@ async function _authToken(): Promise<string | undefined> {
   }
 }
 
+// SEC (U28): only retry idempotent methods. Retrying POST/PATCH/PUT/DELETE on
+// 429/5xx/network errors can duplicate side effects (double checkout, double
+// save, repeated destructive mutations).
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
 async function apiFetch<T>(path: string, options: ApiOptions = {}): Promise<T> {
   const { method = "GET", body, token, signal, cacheTtl } = options;
+  const isIdempotent = IDEMPOTENT_METHODS.has(method.toUpperCase());
+
+  // SEC (U28): reject absolute / protocol-relative paths so the `path` arg
+  // cannot redirect a token-bearing request to an arbitrary host.
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw new Error("[API] path must be a relative path starting with '/'");
+  }
 
   // FETCHPAT-05: Serve from cache for GET requests with cacheTtl set
   if (method === "GET" && cacheTtl && cacheTtl > 0) {
@@ -103,8 +161,8 @@ async function apiFetch<T>(path: string, options: ApiOptions = {}): Promise<T> {
       });
 
       if (!res.ok) {
-        // ERROR-03: Retry on transient server errors
-        if (RETRY_STATUS_CODES.has(res.status) && attempt < MAX_RETRIES) {
+        // ERROR-03: Retry on transient server errors — idempotent methods only.
+        if (RETRY_STATUS_CODES.has(res.status) && isIdempotent && attempt < MAX_RETRIES) {
           const delay = Math.min(1000 * 2 ** attempt, 8000);
           await sleep(delay);
           lastError = new Error(`HTTP ${res.status}: ${res.statusText}`);
@@ -137,6 +195,11 @@ async function apiFetch<T>(path: string, options: ApiOptions = {}): Promise<T> {
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
+      // SEC (U28): never retry non-idempotent methods on network errors.
+      if (!isIdempotent) {
+        clearTimeout(timeoutId);
+        throw lastError;
+      }
       if (attempt < MAX_RETRIES) {
         const delay = Math.min(1000 * 2 ** attempt, 8000);
         await sleep(delay);

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -28,11 +28,24 @@ function getEncryptionKey(): string {
 const ENC_PREFIX = "ENC:";
 
 async function getKey(): Promise<CryptoKey> {
-  // Pad/truncate to exactly 32 bytes for AES-256
-  const keyBytes = new TextEncoder().encode(
-    getEncryptionKey().padEnd(32, "0").slice(0, 32)
+  // SEC (U15): derive a full-entropy 32-byte AES-256 key. The previous code did
+  // `key.padEnd(32,"0").slice(0,32)`, which silently accepted short/low-entropy
+  // secrets (zero-padded) and truncated/ignored hex/base64 encoding — quietly
+  // destroying key strength. Require a sufficiently long secret and derive the
+  // key via SHA-256 so the secret's full entropy is used and no key is silently
+  // weakened. (This module has no callers yet, so the derivation change does not
+  // affect any existing ciphertext.)
+  const secret = getEncryptionKey();
+  if (secret.length < 32) {
+    throw new Error(
+      "ENCRYPTION_KEY must be at least 32 characters (e.g. `openssl rand -hex 32`)."
+    );
+  }
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(secret)
   );
-  return crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, [
+  return crypto.subtle.importKey("raw", digest, "AES-GCM", false, [
     "encrypt",
     "decrypt",
   ]);

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -72,6 +72,10 @@ export function buildCsp({ strict, isDev, supabaseOrigin, nonce }: CspOptions): 
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",
+      // SEC (U13): block plugin/embed vectors in the default policy too (this
+      // was only present in the strict policy). Safe, no legitimate <object>/
+      // <embed> usage in the app.
+      "object-src 'none'",
       "upgrade-insecure-requests",
     ];
     return directives.join("; ");

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -1,3 +1,15 @@
+// SEC (U25): escape interpolated user-controlled values (e.g. an OAuth display
+// name or email local-part) before embedding them in email HTML, to prevent
+// HTML/content injection and phishing-style spoofing inside the inbox.
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function baseLayout(content: string): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -61,7 +73,7 @@ export function welcomeEmail(
   if (locale === "ja") {
     const subject = "FaultRay へようこそ — システムのレジリエンスを推定しましょう";
     const html = baseLayout(`
-      <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">${name} 様、はじめまして</h1>
+      <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">${esc(name)} 様、はじめまして</h1>
       <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#94a3b8;">
         7 日間の Business トライアルを開始しました。FaultRay は本番環境に触れず
         2,000+ の障害シナリオをシミュレートできます。
@@ -80,7 +92,7 @@ export function welcomeEmail(
   }
   const subject = "Welcome to FaultRay — Let's estimate your system's resilience";
   const html = baseLayout(`
-    <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Welcome, ${name}!</h1>
+    <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Welcome, ${esc(name)}!</h1>
     <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#94a3b8;">
       Your 7-day Business trial is now active. FaultRay lets you simulate 2,000+ failure scenarios
       — without touching production.
@@ -107,7 +119,7 @@ export function trialReminderEmail(
     const subject = `FaultRay トライアル残り ${daysLeft} 日`;
     const urgencyColor = daysLeft <= 2 ? "#ef4444" : "#FFD700";
     const html = baseLayout(`
-      <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">${name} 様</h1>
+      <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">${esc(name)} 様</h1>
       <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#94a3b8;">
         FaultRay Business トライアルの残り期間は
         <strong style="color:${urgencyColor};">${daysLeft} 日</strong>です。
@@ -123,7 +135,7 @@ export function trialReminderEmail(
   const subject = `Your FaultRay trial ends in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`;
   const urgencyColor = daysLeft <= 2 ? "#ef4444" : "#FFD700";
   const html = baseLayout(`
-    <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Hi ${name},</h1>
+    <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Hi ${esc(name)},</h1>
     <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#94a3b8;">
       Your FaultRay Business trial expires in
       <strong style="color:${urgencyColor};">${daysLeft} day${daysLeft === 1 ? "" : "s"}</strong>.
@@ -148,7 +160,7 @@ export function simulationCompleteEmail(
   const scoreColor = score >= 80 ? "#22c55e" : score >= 60 ? "#FFD700" : "#ef4444";
   const subject = `Simulation complete — Resilience score: ${score}/100`;
   const html = baseLayout(`
-    <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Hi ${name},</h1>
+    <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#f1f5f9;">Hi ${esc(name)},</h1>
     <p style="margin:0 0 24px;font-size:15px;line-height:1.7;color:#94a3b8;">
       Your FaultRay simulation has finished. Here's a summary of your results:
     </p>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -31,6 +31,16 @@ export async function sendEmail({
     return { success: false, error: "No API key" };
   }
 
+  // SEC (U25): defense-in-depth recipient/subject validation. The Resend HTTP
+  // API builds headers server-side, but reject multi-recipient / CRLF payloads
+  // so untrusted input can't smuggle extra recipients or header lines.
+  const recipient = to.trim();
+  if (!/^[^\s@,;]+@[^\s@,;]+\.[^\s@,;]+$/.test(recipient)) {
+    console.error("[email] invalid recipient — not sent");
+    return { success: false, error: "Invalid recipient" };
+  }
+  const safeSubject = subject.replace(/[\r\n]+/g, " ").slice(0, 998);
+
   let lastStatus = 0;
   let lastText = "";
 
@@ -44,8 +54,8 @@ export async function sendEmail({
         },
         body: JSON.stringify({
           from: "FaultRay <noreply@faultray.com>",
-          to,
-          subject,
+          to: recipient,
+          subject: safeSubject,
           html,
         }),
       });

--- a/src/lib/people-risk/queries.ts
+++ b/src/lib/people-risk/queries.ts
@@ -32,13 +32,18 @@ export async function fetchMembers(): Promise<MemberWithSystems[]> {
 export async function fetchMemberById(
   id: string
 ): Promise<MemberWithSystems | null> {
+  // SEC (U32): scope by company in code, not RLS alone. Without the
+  // company_id predicate this is an IDOR — any member id from any tenant would
+  // be readable if the RLS policy is ever weakened/drifted. maybeSingle() so a
+  // cross-tenant id returns null (not a 500).
   const { data, error } = await supabase()
     .from("members")
     .select("*, member_systems(*, systems(*))")
     .eq("id", id)
-    .single();
+    .eq("company_id", DEMO_COMPANY_ID)
+    .maybeSingle();
   if (error) return null;
-  return data as unknown as MemberWithSystems;
+  return (data ?? null) as unknown as MemberWithSystems | null;
 }
 
 /* ── Systems ─────────────────────────────────────────────── */
@@ -69,11 +74,20 @@ export async function updateActionStatus(
   id: string,
   status: Action["status"]
 ): Promise<void> {
-  const { error } = await supabase()
+  // SEC (U32): scope the mutation by company and verify a row was actually
+  // updated. `.update().eq("id")` without a company predicate is a cross-tenant
+  // write under weak RLS; without `.select()` a zero-row update returns no
+  // error and the UI falsely shows success.
+  const { data, error } = await supabase()
     .from("actions")
     .update({ status })
-    .eq("id", id);
+    .eq("id", id)
+    .eq("company_id", DEMO_COMPANY_ID)
+    .select("id");
   if (error) throw error;
+  if (!data || data.length === 0) {
+    throw new Error("Action not found or not in scope");
+  }
 }
 
 /* ── Snapshots ───────────────────────────────────────────── */
@@ -100,14 +114,19 @@ export async function fetchSummary(): Promise<PeopleRiskSummary> {
       .from("systems")
       .select("id")
       .eq("company_id", DEMO_COMPANY_ID),
+    // SEC (U32): scope member_systems to the company too. Previously this read
+    // EVERY visible member_systems row, so under permissive/drifted RLS the
+    // summary aggregated (and leaked counts) across other tenants. Inner-join
+    // to members and filter by company.
     supabase()
       .from("member_systems")
-      .select("system_id, is_sole_owner, risk_level"),
+      .select("system_id, is_sole_owner, risk_level, members!inner(company_id)")
+      .eq("members.company_id", DEMO_COMPANY_ID),
   ]);
 
   const members = (membersRes.data ?? []) as Pick<Member, "id" | "status">[];
   const systems = (systemsRes.data ?? []) as Pick<System, "id">[];
-  const ms = (msRes.data ?? []) as Pick<
+  const ms = (msRes.data ?? []) as unknown as Pick<
     MemberSystem,
     "system_id" | "is_sole_owner" | "risk_level"
   >[];

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -156,10 +156,18 @@ export async function rateLimit(
 
 export function getClientIp(request: Request): string {
   const h = request.headers;
-  const cfIp = h.get("cf-connecting-ip");
-  if (cfIp) return cfIp;
+  // SEC (U14): do NOT blindly trust cf-connecting-ip. Any client can send that
+  // header, and this app is fronted by Vercel (not Cloudflare), so an attacker
+  // could spoof it to evade rate limits or lock out another user. Only honor it
+  // when explicitly deployed behind Cloudflare (TRUST_CF_CONNECTING_IP=1).
+  // Otherwise prefer Vercel's platform-set x-real-ip, which the client cannot
+  // override at the edge.
+  if (process.env.TRUST_CF_CONNECTING_IP === "1") {
+    const cfIp = h.get("cf-connecting-ip");
+    if (cfIp) return cfIp.trim();
+  }
   const realIp = h.get("x-real-ip");
-  if (realIp) return realIp;
+  if (realIp) return realIp.trim();
   const forwarded = h.get("x-forwarded-for");
   if (forwarded) return forwarded.split(",")[0].trim();
   return "anonymous";


### PR DESCRIPTION
Fixes high-severity findings from the dual-model (codex + Kimi, Claude-adjudicated) security review of `faultray-app`. All changes are surgical and verified locally.

## Findings fixed
- **U28 — SSRF / token leak / unsafe retry (`src/lib/api.ts`)**: validate the API base into a trusted origin and **fail closed** on a malformed/insecure base; reject absolute / protocol-relative `path` args; **retry only idempotent methods** (no double-charge / double-submit on POST/PATCH/DELETE); fingerprint tokens in cache keys (no cross-user cache poisoning, no raw token stored).
- **U33 — unauthenticated, email-authorized plan switch (`api/realtime.py`, `src/app/settings/page.tsx`)**: `/api/health` now requires a verified Supabase session and derives the caller from the access token (the request-body `email` is ignored). Removes the service-role plan mutation reachable without auth and the admin-enumeration oracle. Settings page now sends the bearer token.
- **U29 — post-login open redirect + fail-open session**: `login/page.tsx` rejects backslash / protocol-relative `redirectTo` (which `window.location.href` would resolve to an external host); `auth/callback` signs out on profile-bootstrap failure so no authenticated-but-broken session remains reachable.
- **U32 — People-Risk cross-tenant scoping (`src/lib/people-risk/queries.ts`)**: scope `fetchMemberById` / `updateActionStatus` / `fetchSummary` by company in code (defense-in-depth, not RLS alone) and verify affected-row count on update.
- **U15 — weak key derivation (`src/lib/crypto.ts`)**: derive a full-entropy 32-byte AES-256 key via SHA-256 instead of silently zero-padding/truncating short secrets.
- **U16 / U7 — account deletion (`src/app/api/account/delete/route.ts`)**: require strict `confirm === true` (no truthy type-confusion); paginate **all** Stripe subscriptions when cancelling (previously only the first page).
- **U25 — email injection (`src/lib/email*.ts`)**: HTML-escape user-controlled values in templates; validate recipient and strip CRLF from the subject.

## Verification
- `npm run typecheck` ✅  `npm run lint` ✅
- `vitest` on changed modules (api / auth-callback / account-delete) ✅
- `next build` ✅ (full production build, 92/92 static pages) — the only build failure was the env-less container missing `NEXT_PUBLIC_SUPABASE_*`, which are configured on Vercel.

Follow-ups planned in subsequent commits on this branch: rate-limit IP-trust model (U14), cron auth-before-rate-limit (U17), CSP fail-open (U13), and an RLS migration for `member_systems` SELECT drift (U32/U5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_