### PR TITLE
security(follow-up): pin https + reject non-finite score on /api/notify/slack

### DIFF
--- a/src/app/api/notify/slack/route.ts
+++ b/src/app/api/notify/slack/route.ts
@@ -33,8 +33,10 @@ export async function POST(request: Request) {
   if (!webhookUrl || typeof webhookUrl !== "string") {
     return NextResponse.json({ error: "webhookUrl is required" }, { status: 400 });
   }
-  if (typeof score !== "number") {
-    return NextResponse.json({ error: "score is required" }, { status: 400 });
+  if (typeof score !== "number" || !Number.isFinite(score)) {
+    // SEC (U16): reject NaN/Infinity (e.g. JSON `1e999` parses to Infinity),
+    // which would render as "Infinity/100" in the Slack message.
+    return NextResponse.json({ error: "score must be a finite number" }, { status: 400 });
   }
 
   const criticalCount = typeof critical === "number" ? critical : 0;
@@ -47,8 +49,12 @@ export async function POST(request: Request) {
   } catch {
     return NextResponse.json({ error: "webhookUrl must be a Slack incoming webhook URL" }, { status: 400 });
   }
-  if (parsedWebhookUrl.hostname !== "hooks.slack.com") {
-    return NextResponse.json({ error: "webhookUrl must be a Slack incoming webhook URL" }, { status: 400 });
+  // SEC (U25): pin https + exact host. The host check already defeats
+  // `hooks.slack.com.evil.com` / userinfo (`@evil.com`) bypasses; also require
+  // https so the webhook (which embeds a secret token in its path) is never
+  // sent in cleartext.
+  if (parsedWebhookUrl.protocol !== "https:" || parsedWebhookUrl.hostname !== "hooks.slack.com") {
+    return NextResponse.json({ error: "webhookUrl must be an https Slack incoming webhook URL" }, { status: 400 });
   }
 
   const scoreEmoji = score >= 90 ? ":white_check_mark:" : score >= 70 ? ":warning:" : ":red_circle:";


### PR DESCRIPTION
First of the careful follow-up PRs after the released security wave (#157).

## Fixed
- **U25** — `/api/notify/slack` now requires `https:` for the webhook URL. The exact-host check (`hostname === "hooks.slack.com"` via `new URL()`) already defeats `hooks.slack.com.evil.com` and userinfo (`@evil.com`) bypasses; this additionally blocks cleartext `http` (the webhook path embeds a secret token).
- **U16** — reject a non-finite `score` (`NaN`/`Infinity`; JSON `1e999` parses to `Infinity`) instead of rendering `"Infinity/100"` in the Slack message.

## Note from the careful follow-up pass
While working through the remaining review findings, several turned out to be **already mitigated** in the current code and need no change:
- `api/tasks` already rejects non-string/empty `title` (400) and validates cross-tenant `assignee_id`.
- `api/notify/slack` already blocks the `hooks.slack.com.evil.com` host bypass via `new URL().hostname`.
- `checkCsrf` already fails **closed** in production when the origin allowlist is empty.

The genuinely-open items are nuanced/higher-risk and each warrant their own reviewed PR: proxy middleware fail-open (hot path), CSRF on missing `Origin` (legacy same-origin POST compat risk), `member_systems` RLS SELECT drift (DB migration, not verifiable without a live Postgres), and secure org-invite tokens (touches the invite acceptance flow).

## Verification
`npm run typecheck` ✅ · `npm run lint` ✅ · `vitest` 325/325 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_