### PR TITLE
security(U1): close CSRF fail-open on missing Origin via Sec-Fetch-Site

### DIFF
--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -52,8 +52,22 @@ function checkCsrf(request: Request): NextResponse | null {
   }
 
   const origin = request.headers.get("origin");
-  // Origin ヘッダーなし (サーバー間・curl など) は通過させる
-  if (!origin) return null;
+  // Origin ヘッダーなし (サーバー間・curl など) は通過させる…ただし SEC (U1):
+  // 以前は Origin 不在を常に許可していた (CSRF fail-open)。modern browser は
+  // Origin を省いても Sec-Fetch-Site を送るため、Origin 不在 かつ cross-site の
+  // ブラウザリクエストは CSRF として拒否する。Sec-Fetch-Site を送らない
+  // 旧ブラウザ / 非ブラウザ (curl・サーバー間) は従来どおり通過 (additive・
+  // 同一オリジン POST を壊さない)。
+  if (!origin) {
+    const fetchSite = request.headers.get("sec-fetch-site");
+    if (fetchSite === "cross-site" || fetchSite === "cross-origin") {
+      return NextResponse.json(
+        { error: "Forbidden: cross-site request" },
+        { status: 403 }
+      );
+    }
+    return null;
+  }
 
   const allowed = new Set<string>();
 


### PR DESCRIPTION
First of the carefully-staged follow-ups to the released security work (#157, #158). One surgical, additive change.

## U1 — CSRF fail-open on missing `Origin`
`checkCsrf()` previously allowed **any** request without an `Origin` header (intended for server-to-server/curl), which left a CSRF gap. This change rejects an Origin-less request only when the browser-set `Sec-Fetch-Site` is `cross-site`/`cross-origin` (the actual CSRF signal). 

Why this is safe / additive:
- Same-origin browser requests send `Sec-Fetch-Site: same-origin` → unaffected.
- Older browsers / non-browser clients (curl, server-to-server) don't send `Sec-Fetch-Site` → unaffected (same as before).
- The `/api/stripe/webhook` and `/api/cron/` skip-paths are untouched.
- No change to the existing Origin-allowlist path or the production empty-allowlist fail-closed behavior.

## Verification
- `npm run typecheck` ✅
- `vitest` on the auth/CSRF-exercising suites (cron-auth-routes, account-delete-atomic, issue-fixes-codex-audit, auth-flow) — 31 tests ✅

## Still held (each warrants its own dedicated, separately-tested PR)
- **U5** — RLS migration for `member_systems` SELECT drift (needs a local Supabase to validate isolation without breaking the demo seed).
- **U6** — invite token / expiry / single-use / recipient binding (touches the invite-acceptance flow + a schema column).
- **U1 (proxy)** — middleware pass-through when Supabase env is missing (hot path; downstream `requireAuth` still gates, so lower residual risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_