### PR TITLE
test(U5/U35): behavioral pgTAP for People-Risk member_systems RLS

### DIFF
--- a/supabase/migrations/023_people_risk_select_isolation.sql
+++ b/supabase/migrations/023_people_risk_select_isolation.sql
@@ -1,0 +1,98 @@
+-- ============================================================
+-- 023: People-Risk SELECT isolation + demo readability (U32 / #member_systems-drift)
+--
+-- Migration 018 documented that production drifted to a permissive
+-- "Allow read access" SELECT on public.member_systems (and the 004
+-- owner-scoped SELECT policies may be absent there), which allows any
+-- authenticated user to read member-system risk rows (risk_level,
+-- is_sole_owner, notes) across companies — a cross-tenant exposure.
+--
+-- This migration re-establishes a KNOWN-GOOD SELECT policy on every
+-- People-Risk table regardless of the current drifted state:
+--   * owner-scoped: a company's rows are visible only to companies the
+--     caller owns (companies.owner_id = auth.uid()), AND
+--   * demo-readable: the seeded public demo company is readable by any
+--     authenticated user, because the People-Risk feature intentionally
+--     surfaces that sample data via a fixed DEMO_COMPANY_ID (see
+--     src/lib/people-risk/queries.ts). The demo company has owner_id = NULL,
+--     so without this clause an owner-only policy would hide it from everyone.
+--
+-- Idempotent: drops the legacy/owner-only/permissive SELECT policies if
+-- present and recreates a single canonical "owner or demo" SELECT policy.
+-- INSERT/UPDATE/DELETE policies are left as hardened by 004 + 018 (writes
+-- stay strictly owner-scoped; the demo company has no owner so it is
+-- read-only to end users).
+-- ============================================================
+
+-- Fixed seed id, matches 004 seed + queries.ts DEMO_COMPANY_ID.
+-- (Inlined as a literal because RLS policy expressions can't take params.)
+
+-- ── companies ────────────────────────────────────────────────
+drop policy if exists "Allow read access"            on public.companies;
+drop policy if exists "Owner can view own company"   on public.companies;
+drop policy if exists "Owner or demo can view company" on public.companies;
+create policy "Owner or demo can view company"
+  on public.companies for select
+  using (
+    owner_id = auth.uid()
+    or id = '11111111-1111-1111-1111-111111111111'
+  );
+
+-- ── members ──────────────────────────────────────────────────
+drop policy if exists "Allow read access"             on public.members;
+drop policy if exists "Company owner can view members" on public.members;
+drop policy if exists "Owner or demo can view members" on public.members;
+create policy "Owner or demo can view members"
+  on public.members for select
+  using (
+    company_id in (select id from public.companies where owner_id = auth.uid())
+    or company_id = '11111111-1111-1111-1111-111111111111'
+  );
+
+-- ── systems ──────────────────────────────────────────────────
+drop policy if exists "Allow read access"             on public.systems;
+drop policy if exists "Company owner can view systems" on public.systems;
+drop policy if exists "Owner or demo can view systems" on public.systems;
+create policy "Owner or demo can view systems"
+  on public.systems for select
+  using (
+    company_id in (select id from public.companies where owner_id = auth.uid())
+    or company_id = '11111111-1111-1111-1111-111111111111'
+  );
+
+-- ── member_systems (the documented drift) ────────────────────
+drop policy if exists "Allow read access"                   on public.member_systems;
+drop policy if exists "Company owner can view member_systems" on public.member_systems;
+drop policy if exists "Owner or demo can view member_systems" on public.member_systems;
+create policy "Owner or demo can view member_systems"
+  on public.member_systems for select
+  using (
+    member_id in (
+      select m.id
+      from public.members m
+      where m.company_id in (select id from public.companies where owner_id = auth.uid())
+         or m.company_id = '11111111-1111-1111-1111-111111111111'
+    )
+  );
+
+-- ── actions ──────────────────────────────────────────────────
+drop policy if exists "Allow read access"             on public.actions;
+drop policy if exists "Company owner can view actions" on public.actions;
+drop policy if exists "Owner or demo can view actions" on public.actions;
+create policy "Owner or demo can view actions"
+  on public.actions for select
+  using (
+    company_id in (select id from public.companies where owner_id = auth.uid())
+    or company_id = '11111111-1111-1111-1111-111111111111'
+  );
+
+-- ── risk_snapshots ───────────────────────────────────────────
+drop policy if exists "Allow read access"                    on public.risk_snapshots;
+drop policy if exists "Company owner can view risk_snapshots" on public.risk_snapshots;
+drop policy if exists "Owner or demo can view risk_snapshots" on public.risk_snapshots;
+create policy "Owner or demo can view risk_snapshots"
+  on public.risk_snapshots for select
+  using (
+    company_id in (select id from public.companies where owner_id = auth.uid())
+    or company_id = '11111111-1111-1111-1111-111111111111'
+  );

--- a/supabase/tests/rls/multitenant.test.sql
+++ b/supabase/tests/rls/multitenant.test.sql
@@ -54,7 +54,7 @@ create extension if not exists pgtap;
 -- member_systems WITH CHECK:  2 assertion (#83, migration 018, structural existence)
 -- delete_user_account RPC  :  6 assertion (#70 finding 3-5, migration 017)
 --   pre/post check         :  6  (org_p delete via owner CASCADE + cascade chain, org_q untouched)
-select plan(104);
+select plan(110);
 
 -- ============================================================
 -- Setup: auth.users を直接 INSERT して 3 ユーザー + 2 team を作成
@@ -76,6 +76,13 @@ select plan(104);
 \set om_a_p_id  'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
 \set om_b_p_id  'ffffffff-ffff-ffff-ffff-ffffffffffff'
 \set om_c_q_id  '00000000-1111-2222-3333-444444444444'
+-- People-Risk (#U5/U32, migration 023) fixture ids
+\set pr_company_a_id '12121212-aaaa-aaaa-aaaa-121212121212'
+\set pr_company_c_id '13131313-cccc-cccc-cccc-131313131313'
+\set pr_system_a_id  '14141414-aaaa-aaaa-aaaa-141414141414'
+\set pr_system_c_id  '15151515-cccc-cccc-cccc-151515151515'
+\set pr_member_a_id  '16161616-aaaa-aaaa-aaaa-161616161616'
+\set pr_member_c_id  '17171717-cccc-cccc-cccc-171717171717'
 
 -- auth.users (最小フィールド)
 insert into auth.users (id, email, raw_user_meta_data, aud, role)
@@ -113,6 +120,22 @@ insert into public.profiles (id, email, full_name) values
   (:'user_a_id'::uuid, 'a@test.local', 'User A'),
   (:'user_b_id'::uuid, 'b@test.local', 'User B'),
   (:'user_c_id'::uuid, 'c@test.local', 'User C');
+
+-- People-Risk fixtures (#U5/U32, migration 023): real companies owned by A and
+-- C (each with one system + member + member_system) to test member_systems
+-- tenant isolation against the public demo company seeded by migration 004.
+insert into public.companies (id, name, owner_id) values
+  (:'pr_company_a_id'::uuid, 'PR Co A', :'user_a_id'::uuid),
+  (:'pr_company_c_id'::uuid, 'PR Co C', :'user_c_id'::uuid);
+insert into public.systems (id, company_id, name, type) values
+  (:'pr_system_a_id'::uuid, :'pr_company_a_id'::uuid, 'sys-a', 'database'),
+  (:'pr_system_c_id'::uuid, :'pr_company_c_id'::uuid, 'sys-c', 'database');
+insert into public.members (id, company_id, name) values
+  (:'pr_member_a_id'::uuid, :'pr_company_a_id'::uuid, 'PR Member A'),
+  (:'pr_member_c_id'::uuid, :'pr_company_c_id'::uuid, 'PR Member C');
+insert into public.member_systems (member_id, system_id, access_level, is_sole_owner, risk_level) values
+  (:'pr_member_a_id'::uuid, :'pr_system_a_id'::uuid, 'owner', true, 'critical'),
+  (:'pr_member_c_id'::uuid, :'pr_system_c_id'::uuid, 'owner', true, 'critical');
 
 -- team X: owner A, member B
 insert into public.teams (id, name, owner_id) values (:'team_x_id'::uuid, 'Team X', :'user_a_id'::uuid);
@@ -1068,6 +1091,50 @@ deallocate ok_insert;
 deallocate spoof_user;
 deallocate cross_team;
 deallocate null_team;
+
+-- ============================================================
+-- People-Risk member_systems SELECT isolation (#U5/U32, migration 023).
+-- owner-scoped + public demo company (11111111-…) readable to all authenticated
+-- users. Behavioral coverage for the prod RLS drift documented in migration 018.
+-- NOTE: placed BEFORE the delete_user_account block — that test deletes user_a,
+-- which would null pr_company_a.owner_id (ON DELETE SET NULL) and invalidate
+-- the owner-scoped assertions.
+-- ============================================================
+select test_as_user(:'user_a_id'::uuid);
+select ok(
+  exists(select 1 from public.member_systems ms join public.members m on m.id = ms.member_id
+         where m.company_id = :'pr_company_a_id'::uuid),
+  'people-risk: user_a sees own company member_systems'
+);
+select ok(
+  not exists(select 1 from public.member_systems ms join public.members m on m.id = ms.member_id
+             where m.company_id = :'pr_company_c_id'::uuid),
+  'people-risk: user_a CANNOT see another tenant member_systems (cross-tenant)'
+);
+select ok(
+  exists(select 1 from public.member_systems ms join public.members m on m.id = ms.member_id
+         where m.company_id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'people-risk: user_a sees demo company member_systems (demo readable)'
+);
+
+select test_as_user(:'user_c_id'::uuid);
+select ok(
+  not exists(select 1 from public.member_systems ms join public.members m on m.id = ms.member_id
+             where m.company_id = :'pr_company_a_id'::uuid),
+  'people-risk: user_c CANNOT see user_a tenant member_systems (cross-tenant)'
+);
+
+select test_as_anon();
+select ok(
+  exists(select 1 from public.member_systems ms join public.members m on m.id = ms.member_id
+         where m.company_id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'people-risk: anon sees demo member_systems'
+);
+select ok(
+  not exists(select 1 from public.member_systems ms join public.members m on m.id = ms.member_id
+             where m.company_id = :'pr_company_a_id'::uuid),
+  'people-risk: anon CANNOT see real-tenant member_systems'
+);
 
 -- ============================================================
 -- #70 finding 3-5: delete_user_account RPC が 009 テーブル対応 (migration 017)


### PR DESCRIPTION
Third carefully-staged follow-up. Adds the behavioral RLS test coverage that the review flagged as missing (U35) for the People-Risk tables, locking in migration 023 (#160).

## What
6 new pgTAP assertions in `supabase/tests/rls/multitenant.test.sql` (`plan(104)` → `plan(110)`) for `member_systems` SELECT under migration 023:
- a user **sees their own** company's `member_systems`
- a user **does NOT** see another tenant's (cross-tenant isolation) — both directions
- a user **sees the demo** company's rows (demo readability)
- an **anonymous** caller sees **only the demo**, not real-tenant rows

Fixtures: two real companies owned by `user_a` / `user_c` (each with a member + system + member_system), alongside the demo company seeded by migration 004. The block is placed **before** the `delete_user_account` test because that test deletes `user_a`, which would null `pr_company_a.owner_id` (`ON DELETE SET NULL`).

## Why
The review (U35) noted the RLS pgTAP suite did not cover the People-Risk tables, and `member_systems` was only checked structurally (`WITH CHECK IS NOT NULL`). These behavioral tests guard the U5/U32 fix against regression.

## Verification
Ran the **entire** suite on a local Postgres 16 + pgTAP harness replicating the CI RLS job (auth schema, roles, all 23 migrations, identical grant ordering): **110/110 pass, 0 failures** (was 104/104 baseline). The CI `RLS pgTAP Tests` job runs the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_