### PR TITLE
security(U6): expire stale pending org invites

### DIFF
--- a/src/app/api/cron/trial-expiry/route.ts
+++ b/src/app/api/cron/trial-expiry/route.ts
@@ -59,7 +59,30 @@ export async function POST(request: Request) {
 
   console.info(`[cron/trial-expiry] Downgraded ${downgraded} users`);
 
-  return NextResponse.json({ downgraded });
+  // U6: also expire stale pending org invites (email-based invites never
+  // expired). Non-fatal — a failure here must not block the trial downgrade.
+  let expiredInvites = 0;
+  try {
+    const { data: invData, error: invErr } = await supabase.rpc(
+      "expire_stale_org_invites"
+    );
+    if (invErr) {
+      console.error(
+        "[cron/trial-expiry] expire_stale_org_invites error:",
+        invErr.message
+      );
+    } else if (typeof invData === "number") {
+      expiredInvites = invData;
+    }
+  } catch (e) {
+    console.error(
+      "[cron/trial-expiry] expire_stale_org_invites threw:",
+      e instanceof Error ? e.message : e
+    );
+  }
+  console.info(`[cron/trial-expiry] Expired ${expiredInvites} stale org invites`);
+
+  return NextResponse.json({ downgraded, expiredInvites });
 }
 
 // Vercel Cron invokes cron paths with GET (attaching

--- a/supabase/migrations/024_expire_stale_org_invites.sql
+++ b/supabase/migrations/024_expire_stale_org_invites.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 024: U6 — expire stale pending org invites
+--
+-- org invites are email-based: a row in public.org_members with
+-- status='pending' bound to the invited email (the verified email is the
+-- binding; there is no separate invite token). Those pending rows never
+-- expired, so a long-abandoned invite stayed acceptable indefinitely — e.g.
+-- if an invited mailbox is later recycled to a different person, they could
+-- still join the org. This function expires pending invites older than
+-- max_age_days by setting status='removed' (the same terminal state an admin
+-- removal uses, which the invite route already treats as re-invitable via its
+-- `status <> 'removed'` existing-invite check).
+--
+-- SECURITY DEFINER + service_role-only execute: invoked by the daily
+-- /api/cron/trial-expiry cron (service-role client). Idempotent (CREATE OR
+-- REPLACE).
+-- ============================================================
+
+create or replace function public.expire_stale_org_invites(max_age_days integer default 14)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  expired_count integer;
+begin
+  if max_age_days is null or max_age_days <= 0 then
+    raise exception 'max_age_days must be a positive integer';
+  end if;
+
+  update public.org_members
+     set status = 'removed'
+   where status = 'pending'
+     and invited_at < now() - make_interval(days => max_age_days);
+
+  get diagnostics expired_count = row_count;
+  return expired_count;
+end;
+$$;
+
+-- Only the cron's service-role client may run this (it mutates membership rows).
+revoke all on function public.expire_stale_org_invites(integer) from public;
+revoke all on function public.expire_stale_org_invites(integer) from anon, authenticated;
+grant execute on function public.expire_stale_org_invites(integer) to service_role;

--- a/tests/unit/trial-expiry-cron.test.ts
+++ b/tests/unit/trial-expiry-cron.test.ts
@@ -24,12 +24,12 @@ let rpcResult: { data: Array<{ id: string; email: string }> | null; error: { mes
   data: [],
   error: null,
 };
-let capturedRpcName: string | null = null;
+let capturedRpcNames: string[] = [];
 
 vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(() => ({
     rpc: vi.fn((name: string) => {
-      capturedRpcName = name;
+      capturedRpcNames.push(name);
       return Promise.resolve(rpcResult);
     }),
   })),
@@ -42,7 +42,7 @@ describe("L2: /api/cron/trial-expiry", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "info").mockImplementation(() => undefined);
     rpcResult = { data: [], error: null };
-    capturedRpcName = null;
+    capturedRpcNames = [];
     process.env.CRON_SECRET = "test-secret";  // pragma: allowlist secret
     process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
     process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-key";  // pragma: allowlist secret
@@ -74,13 +74,13 @@ describe("L2: /api/cron/trial-expiry", () => {
     expect(status).toBe(401);
     expect(body.error).toBe("Unauthorized");
     // RPC must not have been called when unauthorized
-    expect(capturedRpcName).toBeNull();
+    expect(capturedRpcNames).toEqual([]);
   });
 
   it("returns 401 with wrong bearer token", async () => {
     const { status } = await invoke({ authorization: "Bearer wrong" });
     expect(status).toBe(401);
-    expect(capturedRpcName).toBeNull();
+    expect(capturedRpcNames).toEqual([]);
   });
 
   it("returns 503 when Supabase env is missing", async () => {
@@ -99,7 +99,7 @@ describe("L2: /api/cron/trial-expiry", () => {
     });
     expect(status).toBe(200);
     expect(body.downgraded).toBe(0);
-    expect(capturedRpcName).toBe("downgrade_expired_trials");
+    expect(capturedRpcNames[0]).toBe("downgrade_expired_trials");
   });
 
   it("returns downgraded count equal to RPC rows", async () => {
@@ -138,7 +138,7 @@ describe("L2: /api/cron/trial-expiry", () => {
 
   it("invokes the exact RPC function name", async () => {
     await invoke({ authorization: "Bearer test-secret" });
-    expect(capturedRpcName).toBe("downgrade_expired_trials");
+    expect(capturedRpcNames[0]).toBe("downgrade_expired_trials");
   });
 
   // Vercel Cron invokes the path with GET; a POST-only route 405s every
@@ -151,12 +151,12 @@ describe("L2: /api/cron/trial-expiry", () => {
     );
     expect(status).toBe(200);
     expect(body.downgraded).toBe(1);
-    expect(capturedRpcName).toBe("downgrade_expired_trials");
+    expect(capturedRpcNames[0]).toBe("downgrade_expired_trials");
   });
 
   it("GET still requires the cron secret", async () => {
     const { status } = await invoke({}, "GET");
     expect(status).toBe(401);
-    expect(capturedRpcName).toBeNull();
+    expect(capturedRpcNames).toEqual([]);
   });
 });


### PR DESCRIPTION
Final carefully-staged follow-up. Adds expiry to the email-based org invite flow (U6).

## What
- New migration `024_expire_stale_org_invites.sql`: a `SECURITY DEFINER` function `expire_stale_org_invites(max_age_days int default 14)` that sets `status='removed'` on `pending` `org_members` whose `invited_at` is older than the cutoff. Execute is granted only to `service_role`; rejects non-positive `max_age_days`.
- Wires it into the existing daily `/api/cron/trial-expiry` cron (one extra RPC call, **non-fatal** — a failure must not block the trial downgrade).

## Why
Org invites are **email-based** (a pending `org_members` row bound to the invited email — the verified email is the binding; there is no token). Those pending rows never expired, so an abandoned invite stayed acceptable indefinitely; if the invited mailbox is later recycled, the new holder could still join the org. `status='removed'` is the same terminal state admin-removal uses, which the invite route already treats as re-invitable (`status <> 'removed'`).

Note: the original review framed U6 as "add invite token/single-use", but this app doesn't use token-link invites — the email binding + migration 013 hardening (pending-only, role-limited inserts) already cover those; **expiry was the genuine residual**, addressed here.

## Verification (local Postgres 16 harness)
Migration applies cleanly; function behavior confirmed: stale pending → `removed`, fresh pending & active rows untouched, `max_age_days=0` rejected. `typecheck`, `lint`, and **full vitest (325)** pass; the trial-expiry cron unit test was updated for the added RPC call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_