### PR TITLE
fix: squash 3 regressions/bugs from the security follow-up review

### DIFF
--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -70,29 +70,13 @@ export async function DELETE(request: Request) {
     const stripeCustomerId =
       (profile?.stripe_customer_id as string | null | undefined) ?? null;
 
-    // 2. Atomic DB deletion via SECURITY DEFINER RPC (#29).
-    //    Replaces a 7-step non-transactional sequence that could leave
-    //    orphan rows on failure. The RPC wraps the whole cascade in a
-    //    single PL/pgSQL transaction and returns per-table counts.
-    const { error: rpcError } = await admin.rpc("delete_user_account", {
-      uid: userId,
-    });
-    if (rpcError) {
-      console.error(
-        "[account/delete] delete_user_account RPC failed:",
-        rpcError.message
-      );
-      return NextResponse.json(
-        { error: "Account deletion failed. Please contact support." },
-        { status: 500 }
-      );
-    }
-
-    // 3. Cancel Stripe subscriptions using the pre-read customer id.
-    //    External call — deliberately outside the DB tx. Failure is
-    //    logged but non-fatal (data cleanup has already succeeded;
-    //    Stripe customer.subscription.deleted webhook will eventually
-    //    reconcile).
+    // 2. Cancel Stripe subscriptions BEFORE any irreversible deletion (U7/bug).
+    //    Previously this ran AFTER the DB+auth delete and swallowed errors: if
+    //    Stripe were unreachable the subscription would keep billing with no
+    //    profile left to reconcile (and no cancellation event is emitted if we
+    //    never cancel, so the webhook can't "eventually reconcile"). We now
+    //    cancel first and ABORT the deletion on failure — the user retries once
+    //    Stripe is reachable; meanwhile account + subscription stay consistent.
     const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
     if (
       stripeCustomerId &&
@@ -129,8 +113,32 @@ export async function DELETE(request: Request) {
         );
       } catch (stripeErr) {
         const msg = stripeErr instanceof Error ? stripeErr.message : "Unknown error";
-        console.error("[account/delete] Stripe cancellation error (non-fatal):", msg);
+        console.error("[account/delete] Stripe cancellation failed — aborting deletion:", msg);
+        return NextResponse.json(
+          {
+            error:
+              "Could not cancel your active subscription right now. Your account was NOT deleted — please try again shortly.",
+          },
+          { status: 502 }
+        );
       }
+    }
+
+    // 3. Atomic DB deletion via SECURITY DEFINER RPC (#29). Runs only after any
+    //    subscription has been cancelled, so a billing record can't outlive the
+    //    account. The RPC wraps the whole cascade in a single PL/pgSQL tx.
+    const { error: rpcError } = await admin.rpc("delete_user_account", {
+      uid: userId,
+    });
+    if (rpcError) {
+      console.error(
+        "[account/delete] delete_user_account RPC failed:",
+        rpcError.message
+      );
+      return NextResponse.json(
+        { error: "Account deletion failed. Please contact support." },
+        { status: 500 }
+      );
     }
 
     // 4. Delete the auth user (point-of-no-return, external to DB tx)

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -62,11 +62,32 @@ export async function DELETE(request: Request) {
     // 1. Pre-read stripe_customer_id BEFORE the atomic delete (#29).
     //    The RPC in step 2 will wipe the profile row, so we must capture
     //    external-system identifiers ahead of time.
-    const { data: profile } = await admin
+    const { data: profile, error: profileError } = await admin
       .from("profiles")
       .select("stripe_customer_id")
       .eq("id", userId)
       .maybeSingle();
+    // SEC/bug: a FAILED read (transient DB fault) must NOT be conflated with
+    // "no Stripe customer". If we swallowed the error, stripeCustomerId would
+    // default to null, the cancellation block below would be skipped, and we'd
+    // proceed to irreversibly delete the account while an active subscription
+    // keeps billing — the exact orphaned-billing failure this ordering exists to
+    // prevent, just triggered by a profile-read fault instead of a Stripe fault.
+    // maybeSingle() returns {data:null,error:null} for a genuine no-row result
+    // (legitimately no profile → nothing to cancel), so only a real error aborts.
+    if (profileError) {
+      console.error(
+        "[account/delete] Profile pre-read failed — aborting deletion to avoid orphaning billing:",
+        profileError.message
+      );
+      return NextResponse.json(
+        {
+          error:
+            "Could not verify your billing state right now. Your account was NOT deleted — please try again shortly.",
+        },
+        { status: 502 }
+      );
+    }
     const stripeCustomerId =
       (profile?.stripe_customer_id as string | null | undefined) ?? null;
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { isSafeInternalPath } from "@/lib/safe-redirect";
 
 export const dynamic = "force-dynamic";
 
@@ -15,41 +16,14 @@ export async function GET(request: Request) {
     return NextResponse.redirect(`${origin}/login?error=${msg}`);
   }
 
-  // SEC-02 / #26: Validate redirectTo via explicit allow-list of internal
-  // app routes. Previous regex `^\/(?:[...]*)$` accepted `//evil.com` and
-  // similar path-normalization traps. While NextResponse.redirect(origin+path)
-  // prevents true cross-origin open redirect, the user-visible URL could
-  // still render as `https://faultray.com//evil.com` which is confusing.
-  // An allow-list of top-level segments removes the attack surface entirely.
-  const SAFE_REDIRECT_PREFIXES: ReadonlyArray<string> = [
-    "/dashboard",
-    "/settings",
-    "/simulate",
-    "/projects",
-    "/reports",
-    "/compliance",
-    "/dora",
-    "/pricing",
-    "/billing",
-    "/whatif",
-  ];
+  // SEC/#26: validate redirectTo as a SAME-ORIGIN internal path, shared with the
+  // login page (src/lib/safe-redirect). The redirect is built same-origin below
+  // (`${origin}${redirectTo}`), so any internal path that passes is safe from
+  // open-redirect. The previous narrow prefix allow-list silently dropped valid
+  // deep links (e.g. /people-risk/actions) to /dashboard even though the login
+  // page accepted them.
   const rawRedirectTo = searchParams.get("redirectTo") || "/dashboard";
-  const isSafeRedirect = (value: string): boolean => {
-    // Must be a proper internal path (single leading slash, no protocol / authority marker)
-    if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
-      return false;
-    }
-    // Reject path-traversal segments that could normalize out of the
-    // allow-listed prefix (e.g. `/dashboard/../admin` → `/admin`).
-    if (value.includes("..") || value.includes("\\")) {
-      return false;
-    }
-    // Must begin with one of our known top-level segments
-    return SAFE_REDIRECT_PREFIXES.some(
-      (p) => value === p || value.startsWith(`${p}/`) || value.startsWith(`${p}?`) || value.startsWith(`${p}#`)
-    );
-  };
-  const redirectTo = isSafeRedirect(rawRedirectTo) ? rawRedirectTo : "/dashboard";
+  const redirectTo = isSafeInternalPath(rawRedirectTo) ? rawRedirectTo : "/dashboard";
 
   if (code) {
     try {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,22 +7,7 @@ import { Suspense, useState } from "react";
 import { Mail, Loader2, CheckCircle2, Lock } from "lucide-react";
 import { useLocale } from "@/lib/useLocale";
 import { appDict } from "@/i18n/app-dict";
-
-// SEC (U29): accept only same-origin internal paths for post-login redirects.
-function isSafeInternalPath(raw: string | null): boolean {
-  if (!raw) return false;
-  // Single leading slash only; reject protocol-relative (//), backslashes
-  // (browsers fold \ → /, enabling //host) and any path traversal.
-  if (!raw.startsWith("/") || raw.startsWith("//")) return false;
-  if (raw.includes("\\") || raw.includes("..")) return false;
-  // Defense in depth: resolving against an arbitrary origin must stay on it.
-  try {
-    const base = "https://faultray.invalid";
-    return new URL(raw, base).origin === base;
-  } catch {
-    return false;
-  }
-}
+import { isSafeInternalPath } from "@/lib/safe-redirect";
 
 function LoginForm() {
   const locale = useLocale();

--- a/src/lib/people-risk/queries.ts
+++ b/src/lib/people-risk/queries.ts
@@ -74,20 +74,25 @@ export async function updateActionStatus(
   id: string,
   status: Action["status"]
 ): Promise<void> {
-  // SEC (U32): scope the mutation by company and verify a row was actually
-  // updated. `.update().eq("id")` without a company predicate is a cross-tenant
-  // write under weak RLS; without `.select()` a zero-row update returns no
-  // error and the UI falsely shows success.
-  const { data, error } = await supabase()
+  // SEC (U32): keep the company predicate so this can never become a
+  // cross-tenant write under weak RLS.
+  //
+  // NOTE: People-Risk is currently a DEMO-only feature wired to the seeded demo
+  // company (DEMO_COMPANY_ID, owner_id = NULL), which is intentionally
+  // read-only at the RLS layer (migration 023). So this UPDATE legitimately
+  // affects 0 rows and the actions page applies an OPTIMISTIC, per-session
+  // update — interactive but ephemeral. We therefore do NOT throw on a 0-row
+  // result here (an earlier rowcount check broke the demo's "mark done" button:
+  // the throw skipped the optimistic UI update). A genuine DB error still
+  // propagates. If People-Risk becomes real multi-tenant (writable per-org
+  // data), reinstate a rows-affected check so a silently-failed real write
+  // can't masquerade as success.
+  const { error } = await supabase()
     .from("actions")
     .update({ status })
     .eq("id", id)
-    .eq("company_id", DEMO_COMPANY_ID)
-    .select("id");
+    .eq("company_id", DEMO_COMPANY_ID);
   if (error) throw error;
-  if (!data || data.length === 0) {
-    throw new Error("Action not found or not in scope");
-  }
 }
 
 /* ── Snapshots ───────────────────────────────────────────── */

--- a/src/lib/safe-redirect.ts
+++ b/src/lib/safe-redirect.ts
@@ -9,17 +9,39 @@
  * The redirect target is always built same-origin (`${origin}${path}`), so any
  * internal path that passes these checks is safe from open-redirect. We reject:
  *   - non-strings / empty
- *   - values with leading/trailing whitespace (must be a clean path)
+ *   - any whitespace (a clean path has none; a literal space would be `%20`)
  *   - protocol-relative (`//host`) and backslash variants (browsers fold `\`→`/`,
  *     enabling `//host`)
- *   - path traversal (`..`)
+ *   - path traversal (`..`), including percent-encoded (`%2e%2e`) and
+ *     double-encoded (`%252e`) forms, and encoded backslash (`%5c`)
  *   - anything that doesn't resolve to the same origin
  */
 export function isSafeInternalPath(raw: string | null | undefined): boolean {
   if (typeof raw !== "string" || raw.length === 0) return false;
-  if (raw !== raw.trim()) return false;
+  // No whitespace anywhere. A legitimate space in a query is percent-encoded
+  // (`%20`); a raw space/tab/newline means the value isn't a clean path. This
+  // also subsumes the old leading/trailing-trim check.
+  if (/\s/.test(raw)) return false;
   if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) return false;
   if (raw.includes("\\") || raw.includes("..")) return false;
+  // Defeat percent-encoded traversal / backslash (`/%2e%2e/admin`, `/%5cevil`).
+  // `new URL` decodes and normalizes `%2e%2e` to `..`, so the literal check above
+  // misses it. Decode repeatedly so double-encoding (`%252e` → `%2e` → `.`)
+  // can't smuggle a segment past us, then re-inspect. Malformed encoding (a bare
+  // `%`) makes decodeURIComponent throw — reject those too. We deliberately do
+  // NOT reject decoded whitespace here so legitimate encoded-space query values
+  // (e.g. `/search?q=a%20b`) still pass.
+  let decoded = raw;
+  try {
+    for (let i = 0; i < 3; i++) {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    }
+  } catch {
+    return false;
+  }
+  if (decoded.includes("\\") || decoded.includes("..")) return false;
   try {
     const base = "https://faultray.invalid";
     return new URL(raw, base).origin === base;

--- a/src/lib/safe-redirect.ts
+++ b/src/lib/safe-redirect.ts
@@ -1,0 +1,29 @@
+/**
+ * SEC: validate a post-auth `redirectTo` as a SAME-ORIGIN internal path.
+ *
+ * Used by both the login page and the OAuth callback so they agree on what is
+ * accepted (previously the callback used a narrow hard-coded allow-list that
+ * silently dropped valid deep links like `/people-risk/actions` to
+ * `/dashboard`, while the login page accepted them — an inconsistency).
+ *
+ * The redirect target is always built same-origin (`${origin}${path}`), so any
+ * internal path that passes these checks is safe from open-redirect. We reject:
+ *   - non-strings / empty
+ *   - values with leading/trailing whitespace (must be a clean path)
+ *   - protocol-relative (`//host`) and backslash variants (browsers fold `\`→`/`,
+ *     enabling `//host`)
+ *   - path traversal (`..`)
+ *   - anything that doesn't resolve to the same origin
+ */
+export function isSafeInternalPath(raw: string | null | undefined): boolean {
+  if (typeof raw !== "string" || raw.length === 0) return false;
+  if (raw !== raw.trim()) return false;
+  if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) return false;
+  if (raw.includes("\\") || raw.includes("..")) return false;
+  try {
+    const base = "https://faultray.invalid";
+    return new URL(raw, base).origin === base;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/account-delete-atomic.test.ts
+++ b/tests/unit/account-delete-atomic.test.ts
@@ -48,6 +48,7 @@ vi.mock("stripe", () => {
 let _profileRow: { stripe_customer_id: string | null } | null = {
   stripe_customer_id: "cus_test_abc",
 };
+let _profileError: { message: string } | null = null;
 let _rpcError: { message: string } | null = null;
 let _deleteAuthError: { message: string } | null = null;
 const _rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -61,7 +62,7 @@ vi.mock("@supabase/supabase-js", () => ({
           eq: (_col: string, val: string) => ({
             maybeSingle: async () => {
               _profileSelectCalls.push({ eq: val });
-              return { data: _profileRow, error: null };
+              return { data: _profileError ? null : _profileRow, error: _profileError };
             },
           }),
         }),
@@ -87,6 +88,7 @@ describe("L2: /api/account/delete — atomic RPC + Stripe preserve (#29)", () =>
     vi.spyOn(console, "info").mockImplementation(() => undefined);
     _getUserOverride = { user: _mockUser, error: null };
     _profileRow = { stripe_customer_id: "cus_test_abc" };
+    _profileError = null;
     _rpcError = null;
     _deleteAuthError = null;
     _rpcCalls.length = 0;
@@ -170,6 +172,19 @@ describe("L2: /api/account/delete — atomic RPC + Stripe preserve (#29)", () =>
     expect(status).toBe(502);
     expect(body.deleted).toBeUndefined();
     expect(_rpcCalls).toHaveLength(0); // deletion did not proceed
+  });
+
+  it("aborts deletion (502) when the profile pre-read errors — no orphaned billing", async () => {
+    // A transient DB fault reading stripe_customer_id must NOT be treated as
+    // "no customer". Deleting anyway would orphan an active subscription with no
+    // profile left to reconcile.
+    _profileError = { message: "connection reset by peer" };
+
+    const { status, body } = await invoke();
+    expect(status).toBe(502);
+    expect(body.deleted).toBeUndefined();
+    expect(_rpcCalls).toHaveLength(0); // deletion did not proceed
+    expect(_mockStripeCancel).not.toHaveBeenCalled();
   });
 
   it("skips Stripe when stripe_customer_id is null", async () => {

--- a/tests/unit/account-delete-atomic.test.ts
+++ b/tests/unit/account-delete-atomic.test.ts
@@ -93,6 +93,10 @@ describe("L2: /api/account/delete — atomic RPC + Stripe preserve (#29)", () =>
     _profileSelectCalls.length = 0;
     _mockStripeList.mockReset();
     _mockStripeCancel.mockReset();
+    // Default: no subscriptions. The cancel-before-delete path now always runs
+    // (when a stripe_customer_id is present), so list() needs a sane default.
+    _mockStripeList.mockResolvedValue({ data: [] });
+    _mockStripeCancel.mockResolvedValue({});
     process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
     process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";  // pragma: allowlist secret
     process.env.STRIPE_SECRET_KEY = "sk_test_real";  // pragma: allowlist secret
@@ -147,20 +151,25 @@ describe("L2: /api/account/delete — atomic RPC + Stripe preserve (#29)", () =>
     expect(_mockStripeCancel).toHaveBeenCalledTimes(2);
   });
 
-  it("returns 500 when the RPC fails (and does NOT hit Stripe)", async () => {
+  it("returns 500 when the RPC fails (no subs, so cancel never runs)", async () => {
     _rpcError = { message: "unique_violation" };
 
     const { status } = await invoke();
     expect(status).toBe(500);
+    // Default mock has no subscriptions, so cancel is never invoked.
     expect(_mockStripeCancel).not.toHaveBeenCalled();
   });
 
-  it("Stripe error is non-fatal (deletion still succeeds)", async () => {
+  it("aborts deletion (502) when Stripe cancellation fails — no zombie billing", async () => {
+    // Cancellation now runs BEFORE the irreversible delete; if it fails we must
+    // NOT delete the account (else the subscription keeps billing with nothing
+    // left to reconcile).
     _mockStripeList.mockRejectedValue(new Error("Stripe API down"));
 
     const { status, body } = await invoke();
-    expect(status).toBe(200);
-    expect(body.deleted).toBe(true);
+    expect(status).toBe(502);
+    expect(body.deleted).toBeUndefined();
+    expect(_rpcCalls).toHaveLength(0); // deletion did not proceed
   });
 
   it("skips Stripe when stripe_customer_id is null", async () => {

--- a/tests/unit/auth-callback-redirect.test.ts
+++ b/tests/unit/auth-callback-redirect.test.ts
@@ -23,6 +23,13 @@ describe("L2: isSafeInternalPath (shared post-auth redirect validator)", () => {
       "javascript:alert(1)",
       "/dashboard/../admin", // traversal
       "/dashboard\\..\\admin",
+      "/%2e%2e/admin", // percent-encoded traversal
+      "/%2E%2E/admin", // percent-encoded traversal (upper)
+      "/%252e%252e/admin", // double-encoded traversal
+      "/%5Cevil.com", // percent-encoded backslash
+      "/foo bar", // internal whitespace
+      "/foo\tbar", // internal tab
+      "/foo%", // malformed percent-encoding
       "", // empty
       " /dashboard", // leading whitespace
       "/dashboard ", // trailing whitespace
@@ -48,6 +55,9 @@ describe("L2: isSafeInternalPath (shared post-auth redirect validator)", () => {
       "/people-risk/members/abc",
       "/teams",
       "/audit-log",
+      // legitimate encoded space in a query value must still pass (the tightened
+      // whitespace check only rejects RAW whitespace, not encoded):
+      "/search?q=a%20b",
     ];
     for (const v of good) {
       expect(isSafeInternalPath(v), `expected accept for ${JSON.stringify(v)}`).toBe(true);

--- a/tests/unit/auth-callback-redirect.test.ts
+++ b/tests/unit/auth-callback-redirect.test.ts
@@ -1,78 +1,56 @@
 /**
- * L2 Regression: auth/callback redirectTo allow-list (#26).
+ * L2 Regression: post-auth `redirectTo` validation (#26 + deep-link bugfix).
  *
- * Before #26 the accept regex `^\/(?:[...]*)$` matched `//evil.com` and
- * similar path-normalization traps. Fix is an explicit allow-list of
- * app route prefixes.
- *
- * This test extracts the regex-free logic via readFileSync + eval so
- * we verify the actual source, not a stale copy.
+ * The login page and OAuth callback now share one validator
+ * (src/lib/safe-redirect → isSafeInternalPath). This test exercises the REAL
+ * exported function (no source-string scraping / reimplemented copy), and locks
+ * in both the open-redirect protections and the fix for dropped deep links:
+ * valid internal paths like `/people-risk/actions` must be accepted (previously
+ * the callback's narrow allow-list silently redirected them to /dashboard).
  */
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { isSafeInternalPath } from "@/lib/safe-redirect";
 
-const CALLBACK_PATH = resolve(
-  __dirname,
-  "../../src/app/auth/callback/route.ts"
-);
-
-describe("L2: auth/callback redirectTo allow-list (#26)", () => {
-  it("source no longer uses a permissive regex", () => {
-    const src = readFileSync(CALLBACK_PATH, "utf-8");
-    // The old permissive regex accepted '//evil.com'. Guard against it
-    // returning via refactor.
-    expect(src).not.toMatch(/SAFE_REDIRECT_RE\s*=\s*\/\^\\\//);
-    // Explicit allow-list constant should be present.
-    expect(src).toMatch(/SAFE_REDIRECT_PREFIXES/);
-    // Core app routes we expect to whitelist.
-    for (const route of ["/dashboard", "/settings", "/simulate"]) {
-      expect(src).toContain(`"${route}"`);
-    }
-  });
-
-  it("rejects protocol-relative and backslash variants in the allow-list logic", () => {
-    // Exercise the runtime logic by extracting + executing the predicate.
-    // We re-declare it here mirroring the source exactly — if the source
-    // refactors in a way that changes behavior, the previous test catches
-    // the shape, and this test locks in the behavior.
-    const SAFE_REDIRECT_PREFIXES = [
-      "/dashboard", "/settings", "/simulate", "/projects", "/reports",
-      "/compliance", "/dora", "/pricing", "/billing", "/whatif",
-    ];
-    const isSafeRedirect = (value: string): boolean => {
-      if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) return false;
-      if (value.includes("..") || value.includes("\\")) return false;
-      return SAFE_REDIRECT_PREFIXES.some(
-        (p) => value === p || value.startsWith(`${p}/`) || value.startsWith(`${p}?`) || value.startsWith(`${p}#`)
-      );
-    };
-
-    // Unsafe inputs → false
-    for (const bad of [
+describe("L2: isSafeInternalPath (shared post-auth redirect validator)", () => {
+  it("rejects open-redirect, traversal and malformed values", () => {
+    const bad: Array<string | null | undefined> = [
       "//evil.com",
       "///evil.com",
       "/\\evil.com",
+      "\\\\evil.com",
       "https://evil.com",
-      "/evil-path",        // not in allow-list
-      "/./dashboard",      // path-normalization trap
-      "/dashboard/../admin",
-      "",                  // empty
-      " /dashboard",       // leading whitespace
-    ]) {
-      expect(isSafeRedirect(bad), `expected reject for ${JSON.stringify(bad)}`).toBe(false);
+      "http://evil.com",
+      "javascript:alert(1)",
+      "/dashboard/../admin", // traversal
+      "/dashboard\\..\\admin",
+      "", // empty
+      " /dashboard", // leading whitespace
+      "/dashboard ", // trailing whitespace
+      "evil.com", // no leading slash
+      null,
+      undefined,
+    ];
+    for (const v of bad) {
+      expect(isSafeInternalPath(v), `expected reject for ${JSON.stringify(v)}`).toBe(false);
     }
+  });
 
-    // Safe inputs → true
-    for (const good of [
+  it("accepts same-origin internal paths, including deep links", () => {
+    const good = [
       "/dashboard",
       "/dashboard/",
       "/dashboard/123",
       "/settings?tab=account",
       "/compliance#soc2",
       "/whatif",
-    ]) {
-      expect(isSafeRedirect(good), `expected accept for ${JSON.stringify(good)}`).toBe(true);
+      // deep links the old narrow allow-list dropped to /dashboard:
+      "/people-risk/actions",
+      "/people-risk/members/abc",
+      "/teams",
+      "/audit-log",
+    ];
+    for (const v of good) {
+      expect(isSafeInternalPath(v), `expected accept for ${JSON.stringify(v)}`).toBe(true);
     }
   });
 });


### PR DESCRIPTION
A re-review (codex, Claude-verified) of the merged security work surfaced **3 high-confidence bugs** (one a regression from the earlier PRs). This PR squashes all three.

## Bugs fixed
**[HIGH] `account/delete` — subscription could keep billing after deletion**
Stripe cancellation ran *after* the irreversible DB+auth delete and only logged errors. On a Stripe outage the account data was gone but the subscription kept billing — and since we never cancelled, no `customer.subscription.deleted` webhook fires to "reconcile". Now: **cancel before** the delete, and **abort (502, account NOT deleted)** if cancellation fails (user retries when Stripe is reachable). Test updated to assert the abort + that the RPC is not called.

**[MED] People-Risk "mark done" silently did nothing (regression)**
`updateActionStatus` added a rows-affected check that throws; but People-Risk is wired to the seeded demo company (`owner_id NULL` → RLS read-only → 0 rows), and the actions page caught the throw and skipped its optimistic update. Reverted the throw for this demo-only, read-only feature (optimistic per-session UI), keeping the `company_id` predicate; documented when to reinstate it (real multi-tenant write path).

**[MED] OAuth callback dropped valid deep links**
The callback's redirect allow-list was narrower than the login page's, so `/people-risk/actions` etc. were silently sent to `/dashboard`. Extracted **one shared same-origin validator** (`src/lib/safe-redirect.ts`) used by both login and callback (the redirect is built same-origin, so any internal path that passes is safe). Rewrote the callback test to exercise the **real** exported validator (previously it scraped source / reimplemented the predicate).

## Verification
`typecheck` ✅, `lint` ✅, **full vitest 325/325** ✅. (CI re-runs RLS pgTAP / Build / Vercel preview.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_