### PR TITLE
security(#85): make nonce-based CSP the default, drop 'unsafe-inline'

### DIFF
--- a/docs/csp-nonce-plan.md
+++ b/docs/csp-nonce-plan.md
@@ -42,28 +42,33 @@ the app produce. ZAP (mattyopon/faultray#172) flags both `script-src` and
       on `style-src`. Inline style *attributes* (React `style={{…}}`, which a
       nonce cannot cover) are kept working via `style-src-attr 'unsafe-inline'`,
       so `style-src` itself is `unsafe-inline`-free.
-- [x] Strict mode ships behind `FAULTRAY_CSP_STRICT=1` so the change can be
-      verified on a preview deploy without a production rollback. When unset,
-      `buildCsp` returns the historical `'unsafe-inline'` policy unchanged and
-      pages render statically as before.
-- [ ] **Operator step:** set `FAULTRAY_CSP_STRICT=1` on a Vercel **preview**
-      deploy and verify (no CSP violations in the console; GA4 / Hotjar /
-      Stripe load; fonts + inline styles render; hydration works on app pages).
-- [ ] Flip the default on (set `FAULTRAY_CSP_STRICT=1` in production) once
-      preview telemetry is clean, then drop the flag and make strict the default
-      in a follow-up.
+- [x] Strict mode is now the **default** (#85): `cspStrictEnabled()` returns
+      true unless `FAULTRAY_CSP_STRICT=0`. The historical `'unsafe-inline'`
+      policy is retained only as an opt-out / rollback path.
+- [x] **Rollback hatch:** setting `FAULTRAY_CSP_STRICT=0` (Vercel env, then
+      redeploy) instantly restores the `'unsafe-inline'` policy **and** static
+      rendering / CDN caching — no code change needed — if a nonce-propagation
+      issue surfaces on a deploy.
+- [ ] **Post-deploy smoke check (operator):** after this ships, confirm on the
+      live deploy that there are no CSP violations in the browser console, GA4 /
+      Hotjar / Stripe load, fonts + inline styles render, and hydration works on
+      app pages. If anything breaks, set `FAULTRAY_CSP_STRICT=0`, redeploy, and
+      nonce the offending script.
 
 ## Tradeoff: dynamic rendering
 
-Nonce-based CSP requires per-request rendering, so when `FAULTRAY_CSP_STRICT=1`
-every page is dynamically rendered (no static optimization / CDN caching, higher
-server cost). This is why it is staged behind the flag rather than flipped on
-unconditionally. With the flag off there is **no** rendering change.
+Nonce-based CSP requires per-request rendering, so with strict mode on (the
+default) every page is dynamically rendered (no static optimization / CDN
+caching, higher server cost). This is the accepted cost of removing
+`'unsafe-inline'`. Setting `FAULTRAY_CSP_STRICT=0` reverts to the static
+`'unsafe-inline'` policy if the caching/cost tradeoff ever needs to be undone.
 
-## Why not cut over immediately
+## Residual risk + rollback
 
 Next.js 16 ships internal inline scripts (hydration marker, route prefetch)
-whose nonce propagation should be handled automatically via the request CSP
-header, but cannot be browser-verified from CI here. A flag-gated rollout lets
-the nonce path be validated on a preview before it becomes the production
-default, without bricking hydration for every user.
+whose nonce propagation is handled automatically via the request CSP header
+(confirmed against `node_modules/next/dist/docs/.../content-security-policy.md`,
+"How nonces work in Next.js"), but cannot be browser-verified from CI here.
+That is why the `FAULTRAY_CSP_STRICT=0` rollback hatch is retained rather than
+dropped: if hydration breaks on the live deploy, ops flip the env var and
+redeploy to instantly restore the previous behavior, no code revert needed.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Breadcrumb } from "@/components/breadcrumb";
 import { LocaleProvider } from "@/lib/useLocale";
 import { CookieConsent } from "@/components/cookie-consent";
 import { ResearchPrototypeBanner } from "@/components/research-prototype-banner";
+import { cspStrictEnabled } from "@/lib/csp";
 import "./globals.css";
 
 const inter = Inter({
@@ -151,14 +152,14 @@ const jsonLd = [
   },
 ];
 
-// #32 / #85: strict (nonce-based) CSP is staged behind FAULTRAY_CSP_STRICT.
-// When on, the layout reads the per-request nonce (set by src/proxy.ts) and
-// stamps it on every executable inline / third-party <script>, and reading
-// headers() opts the tree into dynamic rendering — which nonce-based CSP
-// requires. When off, we skip headers() entirely so static rendering (and CDN
-// caching) is preserved and scripts run under the historical 'unsafe-inline'
-// policy. See docs/csp-nonce-plan.md.
-const STRICT_CSP = process.env.FAULTRAY_CSP_STRICT === "1";
+// #32 / #85: strict (nonce-based) CSP is the default. The layout reads the
+// per-request nonce (set by src/proxy.ts) and stamps it on every executable
+// inline / third-party <script>; reading headers() opts the tree into dynamic
+// rendering — which nonce-based CSP requires. The rollback hatch
+// FAULTRAY_CSP_STRICT=0 (see cspStrictEnabled) skips headers() entirely so
+// static rendering (and CDN caching) is preserved and scripts run under the
+// historical 'unsafe-inline' policy. See docs/csp-nonce-plan.md.
+const STRICT_CSP = cspStrictEnabled();
 
 export default async function RootLayout({
   children,

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -2,12 +2,12 @@
  * Content-Security-Policy builder (#32 / #85, ZAP mattyopon/faultray#172).
  *
  * Two modes:
- *  - default (`strict: false`): keeps `'unsafe-inline'` on script-src/style-src.
- *    This is the historical policy, served while the nonce migration is staged
- *    behind `FAULTRAY_CSP_STRICT`. Output is byte-for-byte the policy that used
- *    to live in next.config.ts, so moving CSP generation into src/proxy.ts does
- *    not change the live default policy.
- *  - strict (`strict: true` + a per-request `nonce`): removes `'unsafe-inline'`
+ *  - non-strict (`strict: false`): keeps `'unsafe-inline'` on script-src/style-src.
+ *    This is the historical policy, now retained only as the opt-out / rollback
+ *    path (`FAULTRAY_CSP_STRICT=0`, see `cspStrictEnabled`). Output is
+ *    byte-for-byte the policy that used to live in next.config.ts.
+ *  - strict (`strict: true` + a per-request `nonce`): the DEFAULT (#85). Removes
+ *    `'unsafe-inline'`
  *    from script-src (replaced by `'nonce-…'` + `'strict-dynamic'`) and from
  *    style-src ELEMENTS (replaced by `'nonce-…'`). Inline style ATTRIBUTES —
  *    which React emits for `style={{…}}` and which a nonce cannot cover — are
@@ -54,6 +54,22 @@ function connectSrc(supabaseOrigin: string): string {
   ]
     .filter(Boolean)
     .join(" ");
+}
+
+/**
+ * Whether the strict (nonce-based, `'unsafe-inline'`-free) CSP is active.
+ *
+ * Strict CSP is now the DEFAULT (#85). It is only disabled when
+ * `FAULTRAY_CSP_STRICT` is explicitly set to `"0"` — an operational escape
+ * hatch that restores the historical `'unsafe-inline'` policy (and with it
+ * static rendering / CDN caching) without a code change, e.g. for an emergency
+ * rollback if a nonce-propagation issue surfaces on a deploy. Any other value
+ * (unset, "1", "true", …) keeps strict mode on.
+ */
+export function cspStrictEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.FAULTRAY_CSP_STRICT !== "0";
 }
 
 export function buildCsp({ strict, isDev, supabaseOrigin, nonce }: CspOptions): string {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { buildCsp } from "@/lib/csp";
+import { buildCsp, cspStrictEnabled } from "@/lib/csp";
 
 const locales = ["en", "ja", "de", "fr", "zh", "ko", "es", "pt"];
 const defaultLocale = "en";
@@ -101,11 +101,12 @@ export async function proxy(request: NextRequest) {
   crypto.getRandomValues(_nonceBytes);
   const nonce = Buffer.from(_nonceBytes).toString("base64");
 
-  // Strict (nonce-based) CSP is staged behind FAULTRAY_CSP_STRICT so the
-  // 'unsafe-inline' removal can be verified on a preview before becoming the
-  // production default (see docs/csp-nonce-plan.md, Phase 3). When the flag is
-  // off, buildCsp() returns the historical 'unsafe-inline' policy unchanged.
-  const strictCsp = process.env.FAULTRAY_CSP_STRICT === "1";
+  // Strict (nonce-based) CSP is the default (#85): it removes 'unsafe-inline'
+  // from script-src/style-src. Setting FAULTRAY_CSP_STRICT=0 falls back to the
+  // historical 'unsafe-inline' policy (and restores static rendering / CDN
+  // caching) without a code change — an emergency rollback hatch only. See
+  // docs/csp-nonce-plan.md.
+  const strictCsp = cspStrictEnabled();
   const cspValue = buildCsp({
     strict: strictCsp,
     isDev: process.env.NODE_ENV === "development",

--- a/tests/security/csp-builder.test.ts
+++ b/tests/security/csp-builder.test.ts
@@ -8,9 +8,24 @@
  *     still permitted via style-src-attr.
  */
 import { describe, it, expect } from "vitest";
-import { buildCsp } from "../../src/lib/csp";
+import { buildCsp, cspStrictEnabled } from "../../src/lib/csp";
 
 const SUPA = "https://proj.supabase.co";
+
+describe("cspStrictEnabled — strict is the default (#85)", () => {
+  it("is on when the flag is unset", () => {
+    expect(cspStrictEnabled({})).toBe(true);
+  });
+
+  it("is on for any value other than '0'", () => {
+    expect(cspStrictEnabled({ FAULTRAY_CSP_STRICT: "1" })).toBe(true);
+    expect(cspStrictEnabled({ FAULTRAY_CSP_STRICT: "true" })).toBe(true);
+  });
+
+  it("is the ONLY off switch: FAULTRAY_CSP_STRICT='0' (rollback hatch)", () => {
+    expect(cspStrictEnabled({ FAULTRAY_CSP_STRICT: "0" })).toBe(false);
+  });
+});
 
 describe("buildCsp — default (non-strict) policy", () => {
   const csp = buildCsp({ strict: false, isDev: false, supabaseOrigin: SUPA });


### PR DESCRIPTION
## What

Flips the already-wired **nonce-based Content-Security-Policy** from being gated *off* behind `FAULTRAY_CSP_STRICT=1` to being the **production default**. This removes `'unsafe-inline'` from the live `script-src` / `style-src` — the exact weakness ZAP flags in mattyopon/faultray#172 and tracked as #85.

## Why

The scaffolding (per-request nonce in `src/proxy.ts`, nonce stamped on every executable inline / third-party `<script>` in the root layout, Next.js auto-propagating the nonce to its own framework scripts via the request `Content-Security-Policy` header) was complete but inert: with the flag off, production still served `script-src 'self' 'unsafe-inline' …`. `'unsafe-inline'` neutralises CSP's core XSS protection, so #85 stayed open.

## How

- **`src/lib/csp.ts`** — new, testable `cspStrictEnabled()` helper: strict **unless** `FAULTRAY_CSP_STRICT=0`.
- **`src/proxy.ts`, `src/app/layout.tsx`** — use the helper; strict is now the default.
- Strict policy: `script-src` uses `'nonce-…' 'strict-dynamic'`; `style-src` uses `'nonce-…'`; React inline style **attributes** (`style={{…}}`, which a nonce can't cover) stay working via `style-src-attr 'unsafe-inline'`, so `style-src` itself is `unsafe-inline`-free.
- **`tests/security/csp-builder.test.ts`** — cover the default-on + `=0` rollback switch.
- **`docs/csp-nonce-plan.md`** — Phase 3 marked done; default + rollback documented.

## Tradeoff (please read)

Nonce-based CSP **requires per-request dynamic rendering**, so with strict on (the default) every page is dynamically rendered — **no static optimization / CDN caching**, higher server cost. This is the documented, inherent cost of removing `'unsafe-inline'` (confirmed against `node_modules/next/dist/docs/01-app/02-guides/content-security-policy.md`).

## Rollback hatch

Next.js' framework-script nonce propagation can't be browser-verified in CI here, so the historical policy is retained as an instant escape hatch: set **`FAULTRAY_CSP_STRICT=0`** in Vercel env and redeploy to restore `'unsafe-inline'` + static rendering with **no code change**, should any hydration/CSP issue surface on the live deploy.

## Verification

- `vitest run` — 333/333 pass (CSP builder 15, CSP headers 7, incl. 3 new)
- `tsc --noEmit` clean · `eslint` clean
- ⚠️ **Post-deploy operator step:** smoke-check the live deploy (no CSP violations in console; GA4 / Hotjar / Stripe load; fonts + inline styles render; hydration works on app pages). Roll back via `FAULTRAY_CSP_STRICT=0` if needed.

Closes #85. Addresses the `script-src`/`style-src 'unsafe-inline'` items in mattyopon/faultray#172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Xh5wLd32gvMbcUHm2CJG)_