### PR TITLE
ci(migrations): reject direct (IPv6-only) SUPABASE_DB_URL early

### DIFF
--- a/.github/workflows/apply-migrations.yml
+++ b/.github/workflows/apply-migrations.yml
@@ -102,6 +102,19 @@ jobs:
             echo "::error::SUPABASE_DB_URL secret is not set (use the Session pooler connection string)"
             exit 1
           fi
+          # Preflight: the direct (db.<ref>.supabase.co) host is IPv6-only and
+          # GitHub-hosted runners have no IPv6 — psql would stall, then fail
+          # with an opaque timeout. Catch the wrong connection string here with
+          # an actionable message. (Never echo $SUPABASE_DB_URL — it has the pwd.)
+          case "$SUPABASE_DB_URL" in
+            *@db.*.supabase.co:*|*@db.*.supabase.co/*)
+              echo "::error::SUPABASE_DB_URL is the DIRECT connection (db.<ref>.supabase.co, IPv6-only) and GitHub runners have no IPv6. Use the Session pooler from Supabase Dashboard -> Connect: postgresql://postgres.<ref>:<pwd>@aws-0-<region>.pooler.supabase.com:5432/postgres"
+              exit 1 ;;
+          esac
+          case "$SUPABASE_DB_URL" in
+            *pooler.supabase.com:6543*)
+              echo "::warning::SUPABASE_DB_URL uses the transaction pooler (port 6543); this workflow expects the Session pooler (port 5432). Continuing, but switch if you hit session/prepared-statement errors." ;;
+          esac
           # Tracking table (idempotent).
           psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -qc "
             create table if not exists public.applied_migrations (


### PR DESCRIPTION
## What

`apply-migrations.yml` requires the Supabase **Session pooler** connection string. The **direct** `db.<ref>.supabase.co` host is IPv6-only and GitHub-hosted runners have no IPv6, so a direct `SUPABASE_DB_URL` makes `psql` stall and then fail with an opaque timeout.

This adds a preflight to the **Apply** step that:
- **Fails fast** with an actionable message when the secret is a direct connection string (`@db.<ref>.supabase.co`), pointing to the Session pooler form.
- **Warns** when the transaction pooler (port `6543`) is used instead of the Session pooler (`5432`), but continues.

The connection string is matched with `case` and **never echoed** (it holds the DB password).

## Why

A misconfigured secret currently surfaces as a multi-minute hang followed by a generic network timeout. This turns it into an immediate, self-explanatory error.

## Testing

- `yaml.safe_load` parses the workflow; `bash -n` of the extracted Apply script passes.
- Guard logic verified against three sample URLs:
  - direct (`@db.<ref>.supabase.co:5432`) → error + `exit 1`
  - Session pooler (`...pooler.supabase.com:5432`) → pass
  - Transaction pooler (`...pooler.supabase.com:6543`) → warning, continue

## Follow-up (no code change)

Verify the repo secret `SUPABASE_DB_URL` is the **Session pooler** URI (Supabase Dashboard → Connect → Session pooler), port **5432** (not `6543`). Secrets can't be read back, so re-set it if unsure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECuCCRtdriA2HG6FaKFC5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECuCCRtdriA2HG6FaKFC5i)_