### PR TITLE
ci(security): add Cross-Origin-Resource-Policy; stage COEP as report-only (ZAP #182)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -61,12 +61,30 @@ const nextConfig: NextConfig = {
             key: "Cross-Origin-Opener-Policy",
             value: "same-origin-allow-popups",
           },
-          // ZAP #172: Cross-Origin-Embedder-Policy (COEP: require-corp) is
-          // intentionally DEFERRED. Enabling it would force every cross-origin
-          // resource (Supabase, Stripe, Google Fonts, GA4/Hotjar, OG images) to
-          // opt in via a Cross-Origin-Resource-Policy / CORP header; any resource
-          // that does not would be blocked, almost certainly breaking the app.
-          // Tracked separately in mattyopon/faultray#172 (follow-up).
+          // ZAP faultray#182: Cross-Origin-Resource-Policy controls who may
+          // embed THIS app's own responses cross-origin. `same-origin` is safe:
+          // the app already sends X-Frame-Options: DENY / frame-ancestors 'none'
+          // (nothing is meant to embed us), CORP is browser-enforced only (it
+          // does not block server-side OG / social-preview crawlers), and it does
+          // not constrain the third-party resources WE load (those carry their
+          // own CORP). Clears the ZAP "CORP header missing" finding on pages/fonts.
+          {
+            key: "Cross-Origin-Resource-Policy",
+            value: "same-origin",
+          },
+          // ZAP faultray#182: Cross-Origin-Embedder-Policy — ENFORCED COEP stays
+          // DEFERRED. Both `require-corp` and `credentialless` gate cross-origin
+          // embeds (Stripe Elements/Checkout iframes js.stripe.com / hooks.stripe.com,
+          // GA4 / Hotjar, Google Fonts, OG images) on a CORP/COEP opt-in they don't
+          // all send — flipping it on would almost certainly break checkout + analytics.
+          // Instead we ship the SAFE first phase: a Report-Only header. It never
+          // blocks anything (so nothing breaks today) but lets the Vercel preview /
+          // browser surface what WOULD be blocked, so a future enforced rollout can
+          // be data-driven. Promote to the enforced header only after that review.
+          {
+            key: "Cross-Origin-Embedder-Policy-Report-Only",
+            value: "credentialless",
+          },
           //
           // Content-Security-Policy is set per request in src/proxy.ts (nonce
           // support under FAULTRAY_CSP_STRICT), not here — see the note at the


### PR DESCRIPTION
## What

Addresses the OWASP ZAP baseline findings in **mattyopon/faultray#182** for the missing **Cross-Origin-Resource-Policy** and **Cross-Origin-Embedder-Policy** headers, in a way that **cannot break runtime**.

Adds to the global header block in `next.config.ts`:

| Header | Value | Mode |
|--------|-------|------|
| `Cross-Origin-Resource-Policy` | `same-origin` | **enforced** |
| `Cross-Origin-Embedder-Policy-Report-Only` | `credentialless` | **report-only (non-blocking)** |

## Why this shape (the "don't break it" part)

- **CORP `same-origin` is safe to enforce.** It only governs who may embed *our own* responses cross-origin. The app already sends `X-Frame-Options: DENY` / `frame-ancestors 'none'` (nothing is meant to embed us); CORP is browser-enforced only, so server-side OG / social-preview crawlers are unaffected; and it does **not** constrain the third-party resources *we* load (they carry their own CORP). CORS API calls (`mode: cors`) are not subject to CORP either. → clears the ZAP "CORP header missing" finding on pages and fonts.
- **Enforced COEP is intentionally NOT flipped on.** Both `require-corp` and `credentialless` gate cross-origin embeds — Stripe Elements/Checkout iframes (`js.stripe.com`, `hooks.stripe.com`), GA4/Hotjar, Google Fonts, OG images — on a CORP/COEP opt-in they don't all send. Enabling it would almost certainly break **checkout + analytics**. This file already documented COEP as deliberately deferred for exactly this reason.
- Instead we ship the **Report-Only** header: it never blocks anything (zero runtime risk today) but lets the Vercel preview / browser surface what *would* be blocked, so a future enforced rollout can be **data-driven** rather than a blind flip.

`Content-Security-Policy` (per-request nonce, `src/proxy.ts`), `COOP`, `HSTS`, `X-Frame-Options`, `nosniff`, `Referrer-Policy`, `Permissions-Policy` are all unchanged.

## Testing

- Pure additive static headers matching the 7 existing entries — no logic change. (Local `tsc`/`build` can't run in this sandbox: deps aren't installed; CI installs them.)
- CI here runs Lint & Type Check + Build + tests; the **Vercel preview** is the place to confirm the live site (and to read any COEP report-only violations in DevTools) before any future decision to enforce COEP.

## Not addressed here (app-level, not header-fixable)

The remaining #182 alerts — *Information Disclosure: sensitive info in URL* and *User-Controllable HTML Element Attribute (potential XSS)* on `/contact` — are app behavior (GET query params / reflected input), not header config; the existing strict nonce CSP already mitigates the XSS class. Can be a separate follow-up if desired.

Refs mattyopon/faultray#182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECuCCRtdriA2HG6FaKFC5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECuCCRtdriA2HG6FaKFC5i)_